### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+#Normalize line endings for Windows
+*.sh text eol=lf


### PR DESCRIPTION
Always convert line endings for *.sh to LF. Fixes `vagrant up` on Windows.

Fixes issue #33 