### PR TITLE
Provision script improvements, and ability to set password from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ cd fbctf
 ./extra/provision.sh prod $PWD
 ```
 
-*Note*: Because this is a production environment, the password will be randomly generated when the provision script finishes. This ensures that you can't forget to change the default password after provisioning. Make sure to watch the very end of the provision script, as the password will be printed out. It will not be stored elsewhere, so either keep track of it or change it. We will add a way to change this password from the command line in the near future (in the meantime, you can figure out how to do it manually by looking at the `import_empty_db` function in `./extra/lib.sh`.
+*Note*: Because this is a production environment, the password will be randomly generated when the provision script finishes. This ensures that you can't forget to change the default password after provisioning. Make sure to watch the very end of the provision script, as the password will be printed out. It will not be stored elsewhere, so either keep track of it or change it. In order to change the password, run the following command:
+
+```
+set_password new_password ctf ctf fbctf $PWD
+```
+
+This will set the password to 'new_password', assuming the database user/password is ctf/ctf and the database name is fbctf (these are the defaults).
 
 The provision script will place the code in the `/var/www/fbctf` directory, install all dependencies, and start the server. In order to run in production mode, we require that you use SSL. The provision script will ask you for your SSL certificate's CSR and key files. More information on setting up SSL is specific in the next session, but note that if you are just testing out the platform and not running it production, you want to use the instructions listed in the Development section below, as this takes care generating certificates for you. We will support Let's Encrypt in the future.
 

--- a/extra/lib.sh
+++ b/extra/lib.sh
@@ -47,7 +47,12 @@ function install_mysql() {
 
 function set_motd() {
   local __path=$1
-  sudo chmod -x /etc/update-motd.d/51-cloudguest
+
+  # If the cloudguest MOTD exists, disable it
+  if [[ -f /etc/update-motd.d/51/cloudguest ]]; then
+    sudo chmod -x /etc/update-motd.d/51-cloudguest
+  fi
+
   sudo cp "$__path/extra/motd-ctf.sh" /etc/update-motd.d/10-help-text
 }
 

--- a/extra/lib.sh
+++ b/extra/lib.sh
@@ -101,6 +101,8 @@ function install_nginx() {
   sudo service nginx restart
 }
 
+# TODO: We should split this function into one where the repo is added, and a
+# second where the repo is installed
 function install_hhvm() {
   local __path=$1
 

--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -2,8 +2,11 @@
 #
 # Facebook CTF: Provision script for vagrant dev environment
 #
-# Usage: ./provision.sh [dev | prod] [path_to_code]
+# Usage: ./provision.sh [dev | prod] [path_to_code] [path_to_destination]
 #
+
+# We want the provision script to fail as soon as there are any errors
+set -e
 
 DB="fbctf"
 U="ctf"
@@ -37,26 +40,26 @@ source "$CTF_PATH/extra/lib.sh"
 # Ascii art is always appreciated
 set_motd "$CTF_PATH"
 
-# Off to a good start...
+# Some people need this language pack installed or HHVM will report errors
 package language-pack-en
-package emacs
 
-# Adding repos for osquery (of course!) and mycli
-repo_osquery
-repo_mycli
+# Repos to be added in dev mode
+if [[ "$MODE" = "dev" ]]; then
+    repo_mycli
+fi
 
 # We only run this once so provisioning is faster
 sudo apt-get update
 
-# Install osquery and mycli
-package osquery
-package mycli
+# Packages to be installed in dev mode
+if [[ "$MODE" = "dev" ]]; then
+    package mycli
+    package emacs
+    package htop
+fi
 
 # Install memcached
 package memcached
-
-# Install htop
-package htop
 
 # Install MySQL
 install_mysql "$P_ROOT"


### PR DESCRIPTION
This PR:

- makes the provision script exit immediately when any command returns a non-zero exit code
- removes dev packages like emacs and mycli from the prod builds
- pulls out the password creation functionality into it's own function, and updates the README with this info

I'm still doing some more robust testing, will let you know when this is OK to merge.