### PR TITLE
first_capture does not return the correct result

### DIFF
--- a/src/data/country-data.php
+++ b/src/data/country-data.php
@@ -76,7 +76,11 @@ class CountryDataController extends DataController {
       }
 
       // Who is the first owner of this level
-      $owner = ($completed_by) ? $completed_by[0] : 'Uncaptured';
+      if ($completed_level) {
+        $owner = await Team::getOwnerLevel($level->getId());
+        $owner = $owner->getName();
+      } else
+        $owner = 'Uncaptured';
       $country_data = (object) array(
         'level_id'    => $level->getId(),
         'title'       => $level->getTitle(),

--- a/src/data/country-data.php
+++ b/src/data/country-data.php
@@ -77,10 +77,11 @@ class CountryDataController extends DataController {
 
       // Who is the first owner of this level
       if ($completed_level) {
-        $owner = await Team::getOwnerLevel($level->getId());
+        $owner = await Team::genFirstCapture($level->getId());
         $owner = $owner->getName();
-      } else
+      } else {
         $owner = 'Uncaptured';
+      }
       $country_data = (object) array(
         'level_id'    => $level->getId(),
         'title'       => $level->getTitle(),

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -490,7 +490,7 @@ class Team extends Model {
     return intval(idx($result->mapRows()[0], 'COUNT(*)'));
   }
 
-  public static async function getOwnerLevel(
+  public static async function genFirstCapture(
     int $level_id,
   ): Awaitable<Team> {
     $db = await self::genDb();

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -490,6 +490,17 @@ class Team extends Model {
     return intval(idx($result->mapRows()[0], 'COUNT(*)'));
   }
 
+  public static async function getOwnerLevel(
+    int $level_id,
+  ): Awaitable<Team> {
+    $db = await self::genDb();
+    $result = await $db->queryf(
+      'SELECT * FROM teams WHERE id = (SELECT team_id FROM scores_log WHERE level_id = %d ORDER BY ts LIMIT 0,1) AND visible = 1 AND active = 1',
+      $level_id,
+    );
+   return self::teamFromRow($result->mapRows()[0]);
+  }
+
   public static async function genCompletedLevel(
     int $level_id,
   ): Awaitable<array<Team>> {


### PR DESCRIPTION
The scoreboard first_capture always return the first team in the order of team name instead of the order of captured time.