### PR TITLE
Configuration option for arbitrary game duration added

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -184,7 +184,8 @@ CREATE TABLE `configuration` (
 LOCK TABLES `configuration` WRITE;
 INSERT INTO `configuration` (field, value, description) VALUES("game", "0", "(Boolean) Game is ongoing");
 INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Date) Next game to happen");
-INSERT INTO `configuration` (field, value, description) VALUES("game_duration", "10800", "(Integer) Duration of game in seconds");
+INSERT INTO `configuration` (field, value, description) VALUES("game_duration_value", "3", "(Integer) Value of the duration of the game");
+INSERT INTO `configuration` (field, value, description) VALUES("game_duration_unit", "h", "(Character) Unit of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("start_ts", "0", "(Integer) Timestamp of start");
 INSERT INTO `configuration` (field, value, description) VALUES("end_ts", "0", "(Integer) Timestamp of end");
 INSERT INTO `configuration` (field, value, description) VALUES("timer", "0", "(Boolean) Timer is enabled");

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -184,7 +184,8 @@ CREATE TABLE `configuration` (
 LOCK TABLES `configuration` WRITE;
 INSERT INTO `configuration` (field, value, description) VALUES("game", "0", "(Boolean) Game is ongoing");
 INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Date) Next game to happen");
-INSERT INTO `configuration` (field, value, description) VALUES("game_duration", "10800", "(Integer) Duration of game in seconds");
+INSERT INTO `configuration` (field, value, description) VALUES("game_duration_value", "3", "(Integer) Value of the duration of the game");
+INSERT INTO `configuration` (field, value, description) VALUES("game_duration_unit", "h", "(Character) Unit of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("start_ts", "0", "(Integer) Timestamp of start");
 INSERT INTO `configuration` (field, value, description) VALUES("end_ts", "0", "(Integer) Timestamp of end");
 INSERT INTO `configuration` (field, value, description) VALUES("timer", "0", "(Boolean) Timer is enabled");

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -153,7 +153,7 @@ class AdminController extends Controller {
     $config = await Configuration::gen('game_duration_unit');
     $duration_unit = $config->getValue();
     $config = await Configuration::gen('game_duration_value');
-    $duration_value = $config->getValue();
+    $duration_value = intval($config->getValue());
 
     $minute_selected = $duration_unit === 'm';
     $hour_selected = $duration_unit === 'h';

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -150,24 +150,28 @@ class AdminController extends Controller {
   }
 
   private async function genConfigurationDurationSelect(): Awaitable<:xhp> {
-    $config = await Configuration::gen('game_duration');
-    $duration = intval($config->getValue());
-    $select = <select name="fb--conf--game_duration"></select>;
+    $config = await Configuration::gen('game_duration_unit');
+    $duration_unit = $config->getValue();
+    $config = await Configuration::gen('game_duration_value');
+    $duration_value = $config->getValue();
 
-    for ($i = 1; $i <= 48; $i++) {
-      $x = 60 * 60 * $i;
-      $x_str = ($i > 1) ? ($i." ".tr('Hours')) : ($i." ".tr('Hour'));
-      $select->appendChild(
-        <option
-          class="fb--conf--game_duration"
-          value={(string) $x}
-          selected={($duration === $x)}>
-          {$x_str}
-        </option>,
-      );
-    }
+    $minute_selected = $duration_unit === 'm';
+    $hour_selected = $duration_unit === 'h';
+    $day_selected = $duration_unit === 'd';
 
-    return $select;
+    return
+      <div class="fb-column-container">
+        <div class="col col-1-2">
+          <input type="number" value={$duration_value} name="fb--conf--game_duration_value" />
+        </div>
+        <div class="col col-2-2">
+          <select name="fb--conf--game_duration_unit">
+            <option class="fb--conf--game_duration" value="m" selected={$minute_selected}>Minutes</option>
+            <option class="fb--conf--game_duration" value="h" selected={$hour_selected}>Hours</option>
+            <option class="fb--conf--game_duration" value="d" selected={$day_selected}>Days</option>
+          </select>
+        </div>
+      </div>;
   }
 
   private async function genLanguageSelect(): Awaitable<:xhp> {

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -153,7 +153,7 @@ class AdminController extends Controller {
     $config = await Configuration::gen('game_duration_unit');
     $duration_unit = $config->getValue();
     $config = await Configuration::gen('game_duration_value');
-    $duration_value = intval($config->getValue());
+    $duration_value = $config->getValue();
 
     $minute_selected = $duration_unit === 'm';
     $hour_selected = $duration_unit === 'h';

--- a/src/inc/gameboard/modules/game-clock.php
+++ b/src/inc/gameboard/modules/game-clock.php
@@ -56,7 +56,11 @@ class ClockModuleController {
     $init = intval($end_ts) - $now;
 
     if ($timer === '1') {
-      $num_hours = intval(floor($init / 3600));
+      $num_days = intval(floor($init / 86400));
+      $days_int = ($num_days >= 0) ? $num_days : 0;
+      $days = sprintf("%02d", $days_int);
+
+      $num_hours = intval(intval($init / 3600) % 24);
       $hours_int = ($num_hours >= 0) ? $num_hours : 0;
       $hours = sprintf("%02d", $hours_int);
 
@@ -75,32 +79,56 @@ class ClockModuleController {
       }
       $milliseconds = sprintf("%02d", $milli_int);
     } else {
+      $days_int = 0;
+      $days = '--';
       $hours = '--';
       $minutes = '--';
       $seconds = '--';
       $milliseconds = '--';
     }
 
+    if ($days_int > 99) {
+      $clock_days_class = "clock-days three-digit";
+    } else {
+      $clock_days_class = "clock-days";
+    }
+
     $indicator = await $this->genGenerateIndicator($start_ts, $end_ts);
-    return
-      <div>
-        <header class="module-header">
-          <h6>{tr('Game Clock')}</h6>
-        </header>
-        <div class="module-content module-scrollable">
-          <div class="game-clock fb-numbers">
-            <span class="clock-hours">{$hours}</span>:
-            <span class="clock-minutes">{$minutes}</span>:
-            <span class="clock-seconds">{$seconds}</span>:
-            <span class="clock-milliseconds">{$milliseconds}</span>
+    if ($days_int > 0) {
+      return
+        <div>
+          <header class="module-header">
+            <h6>Game Clock</h6>
+          </header>
+          <div class="module-content module-scrollable">
+            <div class="game-clock fb-numbers">
+              <span class={$clock_days_class}>{$days}</span>:<span class="clock-hours">{$hours}</span>:<span class="clock-minutes">{$minutes}</span>:<span class="clock-seconds">{$seconds}</span><span class="clock-milliseconds" style="display: none;">{$milliseconds}</span>
+            </div>
+            <div class="game-progress fb-progress-bar">
+              <span class="label label--left">[Start]</span>
+              <span class="label label--right">[End]</span>
+              {$indicator}
+            </div>
           </div>
-          <div class="game-progress fb-progress-bar">
-            <span class="label label--left">[{tr('Start')}]</span>
-            <span class="label label--right">[{tr('End')}]</span>
-            {$indicator}
+        </div>;
+    } else {
+      return
+        <div>
+          <header class="module-header">
+            <h6>Game Clock</h6>
+          </header>
+          <div class="module-content module-scrollable">
+            <div class="game-clock fb-numbers">
+              <span class="clock-days" style="display: none;">{$days}</span><span class="clock-hours">{$hours}</span>:<span class="clock-minutes">{$minutes}</span>:<span class="clock-seconds">{$seconds}</span>:<span class="clock-milliseconds">{$milliseconds}</span>
+            </div>
+            <div class="game-progress fb-progress-bar">
+              <span class="label label--left">[Start]</span>
+              <span class="label label--right">[End]</span>
+              {$indicator}
+            </div>
           </div>
-        </div>
-      </div>;
+        </div>;
+    }
   }
 }
 

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -69,8 +69,21 @@ class Control extends Model {
     await Configuration::genUpdate('start_ts', strval($start_ts));
 
     // Calculate timestamp of the end
-    $config = await Configuration::gen('game_duration');
-    $duration = intval($config->getValue());
+    $config = await Configuration::gen('game_duration_value');
+    $duration_value = intval($config->getValue());
+    $config = await Configuration::gen('game_duration_unit');
+    $duration_unit = $config->getValue();
+    switch ($duration_unit) {
+    case 'd':
+      $duration = $duration_value * 60 * 60 * 24;
+      break;
+    case 'h':
+      $duration = $duration_value * 60 * 60;
+      break;
+    case 'm':
+      $duration = $duration_value * 60;
+      break;
+    }
     $end_ts = $start_ts + $duration;
     await Configuration::genUpdate('end_ts', strval($end_ts));
 

--- a/src/static/css/scss/_gameboard.scss
+++ b/src/static/css/scss/_gameboard.scss
@@ -484,6 +484,11 @@ $module-margin: 20px;
           letter-spacing: .1em;
         }
 
+        span.three-digit{
+          width: 80px;
+          letter-spacing: 0;
+        }
+
         span:before {
           content: "00";
           position: absolute;
@@ -491,6 +496,10 @@ $module-margin: 20px;
           left: 0;
           right: 0;
           top: 0;
+        }
+
+        span.three-digit:before {
+          content: "000"
         }
 
         span:after {
@@ -505,6 +514,10 @@ $module-margin: 20px;
           @include translate(-50%, 0);
 
           text-transform: uppercase;
+        }
+
+        .clock-days:after {
+          content: "day";
         }
 
         .clock-hours:after {

--- a/src/static/js/clock.js
+++ b/src/static/js/clock.js
@@ -11,6 +11,7 @@ function noClock() {
   $('aside[data-module="game-clock"] .clock-seconds').text('--');
   $('aside[data-module="game-clock"] .clock-minutes').text('--');
   $('aside[data-module="game-clock"] .clock-hours').text('--');
+  $('aside[data-module="game-clock"] .clock-days').text('--');
 }
 
 function setMilliseconds(value) {
@@ -33,6 +34,11 @@ function setHours(value) {
   $('aside[data-module="game-clock"] .clock-hours').text(formatted);
 }
 
+function setDays(value) {
+  var formatted = formatNumber(value);
+  $('aside[data-module="game-clock"] .clock-days').text(formatted);
+}
+
 function getMilli() {
   return $('aside[data-module="game-clock"] .clock-milliseconds').text();
 }
@@ -49,19 +55,25 @@ function getHours() {
   return $('aside[data-module="game-clock"] .clock-hours').text();
 }
 
+function getDays() {
+  return $('aside[data-module="game-clock"] .clock-days').text();
+}
+
 module.exports = {
   isRunning: false,
   isStopped: function() {
     return getMilli() === '--' &&
       getSeconds() === '--' &&
       getMinutes() === '--' &&
-      getHours() === '--';
+      getHours() === '--' &&
+      getDays() === '--';
   },
   isFinished: function() {
     return parseInt(getMilli()) === 0 &&
       parseInt(getSeconds()) === 0 &&
       parseInt(getMinutes()) === 0 &&
-      parseInt(getHours()) === 0;
+      parseInt(getHours()) === 0 &&
+      parseInt(getDays()) === 0;
   },
   runClock: function() {
     if (this.isStopped() || this.isFinished()) {
@@ -74,7 +86,7 @@ module.exports = {
     var milli = getMilli();
     var new_milli = parseInt(milli) - 1;
 
-    if (new_milli <= 0) {
+    if (new_milli < 0) {
       var seconds = getSeconds();
       if (parseInt(seconds) > 0) {
         setMilliseconds('99');
@@ -82,24 +94,41 @@ module.exports = {
         setMilliseconds('0');
       }
       var new_seconds = parseInt(seconds) - 1;
-      if (new_seconds <= 0) {
+      if (new_seconds < 0) {
         var minutes = getMinutes();
         if (parseInt(minutes) > 0) {
           setSeconds('59');
+          setMilliseconds('99');
         } else {
           setSeconds('0');
         }
         var new_minutes = parseInt(minutes) - 1;
-        if (new_minutes <= 0) {
+        if (new_minutes < 0) {
           var hours = getHours();
           if (parseInt(hours) > 0) {
             setMinutes('59');
+            setSeconds('59');
+            setMilliseconds('99');
           } else {
             setMinutes('0');
           }
           var new_hours = parseInt(hours) - 1;
-          if (new_hours <= 0) {
-            setHours(0);
+          if (new_hours < 0) {
+            var days = getDays();
+            if (parseInt(days) > 0) {
+              setHours('23');
+              setMinutes('59');
+              setSeconds('59');
+              setMilliseconds('99');
+            } else {
+              setHours('0');
+            }
+            var new_days = parseInt(days) - 1;
+            if (new_days <= 0) {
+              setDays('0');
+            } else {
+              setDays(new_days);
+            }
           } else {
             setHours(new_hours);
           }


### PR DESCRIPTION
As requested in #78 the possibility to select arbitrary game duration is implemented:
![selection_001](https://cloud.githubusercontent.com/assets/12611720/15756346/2700d7ee-2901-11e6-8407-12e7f5d4b26d.jpg)
TODO: if a duration longer than 99 hours is selected, then the Gameclock overlaps:
![selection_002](https://cloud.githubusercontent.com/assets/12611720/15756404/7c4f3a9c-2901-11e6-9002-2fc26b195de4.jpg)
