### PR TITLE
Provisioning: apt-get update before installing language-pack

### DIFF
--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -40,6 +40,9 @@ source "$CTF_PATH/extra/lib.sh"
 # Ascii art is always appreciated
 set_motd "$CTF_PATH"
 
+# We only run this once so provisioning is faster
+sudo apt-get update
+
 # Some people need this language pack installed or HHVM will report errors
 package language-pack-en
 
@@ -47,9 +50,6 @@ package language-pack-en
 if [[ "$MODE" = "dev" ]]; then
     repo_mycli
 fi
-
-# We only run this once so provisioning is faster
-sudo apt-get update
 
 # Packages to be installed in dev mode
 if [[ "$MODE" = "dev" ]]; then


### PR DESCRIPTION
Provisioning failed for language-pack-en because it ran before apt-get update.

```
==> default: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/l/language-pack-en-base/language-pack-en-base_14.04+20140707_all.deb  404  Not Found [IP: 91.189.88.152 80]
```