### PR TITLE
Provisioning: Install language-pack-en after apt-get update

### DIFF
--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -40,9 +40,6 @@ source "$CTF_PATH/extra/lib.sh"
 # Ascii art is always appreciated
 set_motd "$CTF_PATH"
 
-# Some people need this language pack installed or HHVM will report errors
-package language-pack-en
-
 # Repos to be added in dev mode
 if [[ "$MODE" = "dev" ]]; then
     repo_mycli
@@ -50,6 +47,9 @@ fi
 
 # We only run this once so provisioning is faster
 sudo apt-get update
+
+# Some people need this language pack installed or HHVM will report errors
+package language-pack-en
 
 # Packages to be installed in dev mode
 if [[ "$MODE" = "dev" ]]; then


### PR DESCRIPTION
Installing language-pack failed while provisioning because apt wasn't updated at this point.

```
==> default: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/l/language-pack-en-base/language-pack-en-base_14.04+20140707_all.deb  404  Not Found [IP: 91.189.88.152 80]
```