### PR TITLE
Reduce the number of SQL queries when getting map data

### DIFF
--- a/src/data/command-line.php
+++ b/src/data/command-line.php
@@ -15,13 +15,19 @@ class CommandsController extends DataController {
     $results_library = (object) array();
     $results_library_key = "results_library";
 
+    $all_levels = await Level::genAllLevels();
+    $levels_map = Map {};
+    foreach ($all_levels as $level) {
+      $levels_map[$level->getEntityId()] = $level;
+    }
+
     // List of active countries.
     $countries_results = array();
     $countries_key = "country_list";
     $all_enabled_countries = await Country::genAllEnabledCountries();
     foreach ($all_enabled_countries as $country) {
-      $is_active_level =
-        await $country::genIsActiveLevel(intval($country->getId()));
+      $level = $levels_map->get($country->getId());
+      $is_active_level = $level !== null && $level->getActive();
       if ($country->getUsed() && $is_active_level) {
         array_push($countries_results, $country->getName());
       }

--- a/src/data/map-data.php
+++ b/src/data/map-data.php
@@ -13,11 +13,19 @@ class MapDataController extends DataController {
     $my_team_id = SessionUtils::sessionTeam();
     $my_name = SessionUtils::sessionTeamName();
 
+
+    $all_levels = await Level::genAllLevels();
     $enabled_countries = await Country::genAllEnabledCountriesForMap();
+
+    $levels_map = Map {};
+    foreach ($all_levels as $level) {
+      $levels_map[$level->getEntityId()] = $level;
+    }
+
     foreach ($enabled_countries as $country) {
-      $is_active_level = await Country::genIsActiveLevel($country->getId());
+      $country_level = $levels_map->get($country->getId());
+      $is_active_level = $country_level !== null && $country_level->getActive();
       $active = ($country->getUsed() && $is_active_level) ? 'active' : '';
-      $country_level = await Level::genWhoUses($country->getId());
       if ($country_level) {
         $my_previous_score = await ScoreLog::genPreviousScore(
           $country_level->getId(),


### PR DESCRIPTION
Instead of doing a SELECT statement for every single country, we just do two queries, one to get all levels, and one to get active countries.