### PR TITLE
DropKick version bump to fix XSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "d3": "^3.5.16",
-    "dropkickjs": "^2.1.8",
+    "dropkickjs": "^2.1.9",
     "hoverintent-jqplugin": "^0.2.1",
     "jquery": "^2.2.3",
     "keycode": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "d3": "^3.5.16",
-    "dropkickjs": "^2.1.9",
+    "dropkickjs": "^2.1.10",
     "hoverintent-jqplugin": "^0.2.1",
     "jquery": "^2.2.3",
     "keycode": "^2.1.1",


### PR DESCRIPTION
There was a problem with DropKick and Cross Site Scripting, due to the element being assigned the text instead of the encoded innerHTML. See https://github.com/Robdel12/DropKick/pull/338 for the fix.