### PR TITLE
Serve full certificate chain to obtain SSL Labs A+ rating instead of B

### DIFF
--- a/extra/lib.sh
+++ b/extra/lib.sh
@@ -126,7 +126,7 @@ function letsencrypt_cert() {
   fi
 
   /usr/bin/certbot-auto certonly -n --agree-tos --standalone --standalone-supported-challenges tls-sni-01 -m "$__myemail" -d "$__mydomain"
-  sudo ln -s "/etc/letsencrypt/live/$__mydomain/cert.pem" "$1" || true
+  sudo ln -s "/etc/letsencrypt/live/$__mydomain/fullchain.pem" "$1" || true
   sudo ln -s "/etc/letsencrypt/live/$__mydomain/privkey.pem" "$2" || true
 }
 


### PR DESCRIPTION
By serving the full certificate chain instead of only the end entity certificate, the SSL Labs rating of fbctf is raised from B to A+