### PR TITLE
Add Russian translation

### DIFF
--- a/src/language/lang_ru.php
+++ b/src/language/lang_ru.php
@@ -12,7 +12,7 @@ $translations = array(
   'Play' =>
     'Играть',
   'Welcome to the Facebook Capture the Flag Competition. By clicking "Play," you will be entered into the official CTF challenge. Good luck in your conquest.' =>
-    'Добро пожаловать на соревнование Capture the Flag от Facebook. Нажав "Играть", вы примете участие в официальном состязании CTF. Желаем удачи.',
+    'Добро пожаловать на соревнование Capture the Flag от Facebook. Нажмите кнопку "Играть", вы примете участие в официальном состязании CTF. Желаем удачи!',
   'Get ready for the CTF to start and access the gameboard now!' =>
     'Приготовьтесь к началу CTF и получите доступ к игровому полю!',
   'Gameboard' =>
@@ -28,13 +28,13 @@ $translations = array(
   'Upcoming Game' =>
     'Предстоящая Игра',
   '_days' =>
-    '_дней',
+    '_дн.',
   '_hours' =>
-    '_часов',
+    '_ч',
   '_minutes' =>
-    '_минут',
+    '_мин',
   '_seconds' =>
-    '_секунд',
+    '_с',
   'Official CTF Rules' =>
     'Официальные Правила CTF',
   'Following actions are prohibited, unless explicitly told otherwise by event Admins.' =>
@@ -44,25 +44,25 @@ $translations = array(
   'Cooperation' =>
     'Взаимопомощь',
   'No cooperation between teams with independent accounts. Sharing of keys or providing revealing hints to other teams is cheating, don’t do it.' =>
-    'Никакой кооперации и сотрудничества между командами с независимыми аккаунтами. Распространение ключей или предоставление откровенных подсказок другим командам является мошенничеством, не делайте этого.',
+    'Запрещается кооперация и сотрудничество между командами с независимыми аккаунтами. Распространение ключей и предоставление явных подсказок другим командам является мошенничеством и запрещено.',
   'Attacking Scoreboard' =>
-    'Атака Инфраструктуры',
+    'Атака инфраструктуры',
   'No attacking the competition infrastructure. If bugs or vulns are found, please alert the competition organizers immediately.' =>
-    'Никакой атаки на инфраструктуру соревнования. Если были найдены баги или уязвимости, пожалуйста, сообщите об этом организаторам немедленно.',
+    'Запрещены попытки повлиять на инфраструктуру соревнования. В случае обнаружения багов или уязвимостей просим немедленно сообщить о них организаторам.',
   'Sabotage' =>
     'Вредительство',
   'Absolutely no sabotaging of other competing teams, or in any way hindering their independent progress.' =>
-    'Абсолютно никакого вредительства другим командам или затруднения их независимого прогресса любыми способами.',
+    'Строго запрещено вредить другим командам или каким-либо образом мешать их независимому прогрессу.',
   'Bruteforcing' =>
-    'Брутфорс',
+    'Атака полным перебором',
   'No brute forcing of challenge flag/ keys against the scoring site.' =>
-    'Никакого брутфорса flag/ ключей на сайте соревнования.',
+    'Подбор флагов и ключей методом полного перебора на сайте соревнования запрещен.',
   'Denial Of Service' =>
     'DoS-атака',
   'DoSing the CTF platform or any of the challenges is forbidden.' =>
     'DoS-атака на платформу CTF или на любое состязание запрещена.',
   'Legal' =>
-    'Заявление об ограничении ответственности',
+    'Заявление',
   'Disclaimer' =>
     'Disclaimer',
   'By participating in the contest, you agree to release Facebook and its employees, and the hosting organization from any and all liability, claims or actions of any kind whatsoever for injuries, damages or losses to persons and property which may be sustained in connection with the contest. You acknowledge and agree that Facebook et al is not responsible for technical, hardware or software failures, or other errors or problems which may occur in connection with the contest.' =>
@@ -88,7 +88,7 @@ $translations = array(
   'Sign Up' =>
     'Зарегистрироваться',
   'Register to play Capture The Flag here. Once you have registered, you will be logged in.' =>
-    'Зарегистрируйтесь, чтобы сыграть в Capture The Flag. Как только вы зарегистрировались, вы будете оставаться в системе.',
+    'Зарегистрируйтесь, чтобы сыграть в Capture The Flag. После завершения регистрации автоматически будет выполнен вход в систему.',
   'Not Available' =>
     'Недоступно',
   'Team Registration will be open soon, stay tuned!' =>
@@ -100,7 +100,7 @@ $translations = array(
   'Team Login' =>
     'Вход для Команды',
   'Please login here. If you have not registered, you may do so by clicking "Sign Up" below. ' =>
-    'Пожалуйста, войдите. Если вы не регистрировались, вы можете сделать это нажав "Зарегистрироваться" ниже.',
+    'Пожалуйста, выполните вход. Если вы не регистрировались, нажмите кнопку "Зарегистрироваться" ниже.',
   'Team Login will be open soon, stay tuned!' =>
     'Вход для Команды будет скоро открыт, оставайтесь на связи!',
   'ERROR' =>
@@ -110,7 +110,7 @@ $translations = array(
   'Window is too small' =>
     'Окно слишком маленькое',
   'For the best CTF experience, please make window size bigger.' =>
-    'Для наилучших ощущений от игры, пожалуйста, сделайте размер окна больше.',
+    'Для наилучших ощущений от игры увеличьте размер окна.',
   'Thank you.' =>
     'Спасибо.',
   'Logout' =>
@@ -158,19 +158,19 @@ $translations = array(
   'Auto' =>
     'Авто',
   'All Categories' =>
-    'Все Категории',
+    'Все категории',
   'Open' =>
-    'Открыть',
+    'Открытая',
   'Tokenized' =>
-    'Токенизировано',
+    'По токенам',
   'Hour' =>
     'Час',
   'Hours' =>
     'Часы',
   'Used by' =>
-    'Используется',
+    'Использует',
   'Used By' =>
-    'Используется',
+    'Использует',
   'Available' =>
     'Доступно',
   'Registration Tokens' =>
@@ -202,7 +202,7 @@ $translations = array(
   'Registration Type' =>
     'Тип Регистрации',
   'Strong Passwords' =>
-    'Сильные Пароли',
+    'Надежные Пароли',
   'Team Selection' =>
     'Выбор Команды',
   'Game' =>
@@ -210,13 +210,13 @@ $translations = array(
   'Scoring' =>
     'Зарабатывание Очков',
   'Progressive Cycle (s)' =>
-    'Последующий цикл (s)',
+    'Возрастающий цикл (с)',
   'Refresh Gameboard' =>
     'Обновить Игровое Поле',
   'Default Bonus' =>
     'Бонус по Умолчанию',
   'Bases Cycle (s)' =>
-    'Базовый Цикл (s)',
+    'Базовый Цикл (с)',
   'Default Bonus Dec' =>
     'Снижение Бонуса по Умолчанию',
   'Timer' =>
@@ -264,7 +264,7 @@ $translations = array(
   'Export Levels' =>
     'Экспортировать Уровни',
   'Import Categories' =>
-    'Импоритровать Категории',
+    'Импортировать Категории',
   'Export Categories' =>
     'Экспортировать Категории',
   'Levels' =>
@@ -296,7 +296,7 @@ $translations = array(
   'Filter By:' =>
     'Отфильтровать По:',
   'All Status' =>
-    'Статус Всего',
+    'Все статусы',
   'Enabled' =>
     'Включено',
   'Disabled' =>
@@ -336,7 +336,7 @@ $translations = array(
   'Link' =>
     'Ссылка',
   'New Link:' =>
-    'Новая Сылка:',
+    'Новая Ссылка:',
   'Flag Level' =>
     'Уровень Флага',
   'Categories' =>
@@ -348,7 +348,7 @@ $translations = array(
   'Flags Management' =>
     'Управление Флагами',
   'Add Flag Level' =>
-    'Добавить Уровень Флага',
+    'Добавить Уровень с Флагом',
   'New Base Level' =>
     'Новый Уровень Базы',
   'Keep Points' =>
@@ -394,7 +394,7 @@ $translations = array(
   'type' =>
     'тип',
   'pts' =>
-    'очки',
+    'очк',
   'Level' =>
     'Уровень',
   'level' =>
@@ -440,7 +440,7 @@ $translations = array(
   'Add Team' =>
     'Добавить Команду',
   'None' =>
-    'Ничего',
+    'Никто',
   'Logo Name' =>
     'Название Логотипа',
   'Logo Management' =>
@@ -498,8 +498,6 @@ $translations = array(
     'Конец',
   'Rank' =>
     'Ранг',
-  'pts' =>
-    'очк', //points
   'Your Rank' =>
     'Ваш Ранг',
   'Your Score' =>
@@ -524,17 +522,17 @@ $translations = array(
   'hr' =>
     'час', //hour
   'min' =>
-    'минута', //minute
+    'мин', //minute
   'sec' =>
-    'секунда', //second
+    'с', //second
   'ds' =>
-    'дней', //days
+    'дн.', //days
   'hrs' =>
-    'часов', //hours
+    'ч', //hours
   'mins' =>
-    'минут', //minutes
+    'мин', //minutes
   'secs' =>
-    'секунд', //seconds
+    'с', //seconds
   'ago' =>
     'назад',
   //Translations for ModalControllers
@@ -579,7 +577,7 @@ $translations = array(
   'Request Hint' =>
     'Попросить Подсказку',
   'Submit' =>
-    'Подать',
+    'Отправить',
   'hint_' =>
     'подсказка_',
   'first_capture' =>
@@ -615,9 +613,9 @@ $translations = array(
   'total_pts' =>
     'всего_очки',
   'Tool bars are located on all edges of the gameboard. Tap a category to expand and close each tool bar.' =>
-    'Тулбары находятся на всех краях таблицы. Нажмите на категорию, чтобы развернуть и свернуть каждый тулбар.',
+    'На всех краях игрового поля расположены панели инструментов. Выберите категорию, чтобы развернуть и свернуть соответствующую панель инструментов.',
   'Tool_Bars' =>
-    'Тулбары',
+    'Панели_Инструментов',
   'Tap the "Game Clock" to keep track of time during gameplay. Don’t let time get the best of you.' =>
     'Нажмите на "Игровые Часы", чтобы следить за временем во время игры. Не позволяйте времени застать себя врасплох.',
   'Game_Clock' =>
@@ -625,7 +623,7 @@ $translations = array(
   'Countries marked with an ' =>
     'Страны, отмеченные ',
   'are captured by you.' =>
-    ' захваченные вами.',
+    ' захвачены вами.',
   ' are owned by others.' =>
     ' принадлежат другим.',
   'Captures' =>
@@ -633,17 +631,17 @@ $translations = array(
   'Tap Plus[+] to Zoom In. Tap Minus[-] to Zoom Out.' =>
     'Нажмите Плюс[+], чтобы Увеличить масштаб. Нажмите Минус[-], чтобы Уменьшить масштаб.',
   'Click and Drag to move left, right, up and down.' =>
-    'Нажмите и Перетащите, чтобы передвинуть влево, вправо, наверх или вниз.',
+    'Нажмите и перетащите, чтобы передвинуть влево, вправо, наверх или вниз.',
   'Zoom' =>
-    'Масштабировать',
+    'Масштабирование',
   'Tap Forward Slash [/] to activate computer commands. A list of commands can be found under "Rules".' =>
-    'Используйте Слэш [/], чтобы активировать компьютерные команды. Список команд может быть найден в "Правилах".',
+    'Используйте Слэш [/], чтобы активировать компьютерные команды. Список команд можно найти в "Правилах".',
   'Command_Line' =>
     'Командная_Строка',
   'Click "Nav" to access main navigation links like Rules of Play, Registration, Blog, Jobs & more.' =>
     'Нажмите на "Навигацию", чтобы получить основные навигационные ссылки вроде Правил Игры, Регистрации, Блога, Вакансий и проч.',
   'Track your competition by clicking "scorboard" to access real-time game statistics and graphs.' =>
-    'Следите за своим соревнованием через "таблицу", чтобы получать статистику игры и графики в режиме реального времени.',
+    'Следите за ходом соревнования с помощью "таблицы", где можно просматривать статистику игры и графики в режиме реального времени.',
   'Have fun, be the best and conquer the world.' =>
     'Насладитесь игрой, будьте лучшими и захватите мир.',
   'Game_On' =>
@@ -651,9 +649,9 @@ $translations = array(
   'tutorial_' =>
     'обучение_',
   'Next' =>
-    'Следующий',
+    'След.',
   'Skip to play' =>
     'Пропустить',
   'Powered By Facebook' =>
-    'Powered By Facebook',
+    'При поддержке Facebook',
 );

--- a/src/language/lang_ru.php
+++ b/src/language/lang_ru.php
@@ -1,0 +1,659 @@
+<?hh // strict
+
+/* HH_IGNORE_ERROR[1002] */
+$translations = array(
+  'date and time format' =>
+    'H:i:s D d/m/Y', //used by date() function
+  //Translations for IndexController
+  'Facebook CTF' =>
+    'Facebook CTF',
+  'Conquer the world' =>
+    'Покорите мир',
+  'Play' =>
+    'Играть',
+  'Welcome to the Facebook Capture the Flag Competition. By clicking "Play," you will be entered into the official CTF challenge. Good luck in your conquest.' =>
+    'Добро пожаловать на соревнование Capture the Flag от Facebook. Нажав "Играть", вы примете участие в официальном состязании CTF. Желаем удачи.',
+  'Get ready for the CTF to start and access the gameboard now!' =>
+    'Приготовьтесь к началу CTF и получите доступ к игровому полю!',
+  'Gameboard' =>
+    'Игровое поле',
+  'Register Team' =>
+    'Зарегистрировать команду',
+  'Get ready for the CTF to start and register your team now!' =>
+    'Приготовьтесь к началу CTF и зарегистируйте свою команду!',
+  'Login' =>
+    'Войти',
+  'Soon' =>
+    'Скоро',
+  'Upcoming Game' =>
+    'Предстоящая Игра',
+  '_days' =>
+    '_дней',
+  '_hours' =>
+    '_часов',
+  '_minutes' =>
+    '_минут',
+  '_seconds' =>
+    '_секунд',
+  'Official CTF Rules' =>
+    'Официальные Правила CTF',
+  'Following actions are prohibited, unless explicitly told otherwise by event Admins.' =>
+    'Следующие действия запрещены, за исключением случаев, когда администраторы мероприятия явно утверждают обратное.',
+  'Rule' =>
+    'Правило',
+  'Cooperation' =>
+    'Взаимопомощь',
+  'No cooperation between teams with independent accounts. Sharing of keys or providing revealing hints to other teams is cheating, don’t do it.' =>
+    'Никакой кооперации и сотрудничества между командами с независимыми аккаунтами. Распространение ключей или предоставление откровенных подсказок другим командам является мошенничеством, не делайте этого.',
+  'Attacking Scoreboard' =>
+    'Атака Инфраструктуры',
+  'No attacking the competition infrastructure. If bugs or vulns are found, please alert the competition organizers immediately.' =>
+    'Никакой атаки на инфраструктуру соревнования. Если были найдены баги или уязвимости, пожалуйста, сообщите об этом организаторам немедленно.',
+  'Sabotage' =>
+    'Вредительство',
+  'Absolutely no sabotaging of other competing teams, or in any way hindering their independent progress.' =>
+    'Абсолютно никакого вредительства другим командам или затруднения их независимого прогресса любыми способами.',
+  'Bruteforcing' =>
+    'Брутфорс',
+  'No brute forcing of challenge flag/ keys against the scoring site.' =>
+    'Никакого брутфорса flag/ ключей на сайте соревнования.',
+  'Denial Of Service' =>
+    'DoS-атака',
+  'DoSing the CTF platform or any of the challenges is forbidden.' =>
+    'DoS-атака на платформу CTF или на любое состязание запрещена.',
+  'Legal' =>
+    'Заявление об ограничении ответственности',
+  'Disclaimer' =>
+    'Disclaimer',
+  'By participating in the contest, you agree to release Facebook and its employees, and the hosting organization from any and all liability, claims or actions of any kind whatsoever for injuries, damages or losses to persons and property which may be sustained in connection with the contest. You acknowledge and agree that Facebook et al is not responsible for technical, hardware or software failures, or other errors or problems which may occur in connection with the contest.' =>
+    'Принимая участие в соревновании, вы соглашаетесь с полным освобождением компании Facebook, ее сотрудников и компании-организатора мероприятия от любой ответственности, претензий и действий любого характера за травмы, ущерб по отношению к людям, материальным ценностям, а также за пропажу собственности, что может быть связано с соревнованием.',
+  'If you have any questions about what is or is not allowed, please ask an organizer.' =>
+    'Если у вас есть какие-либо вопросы насчет того, что запрещено или разрешено, пожалуйста, обратитесь к организатору.',
+  'Have fun!' =>
+    'Наслаждайтесь!',
+  'Name' =>
+    'Имя',
+  'Email' =>
+    'Email',
+  'Token' =>
+    'Токен',
+  'Team Registration' =>
+    'Регистрация Команды',
+  'Team Name' =>
+    'Название Команды',
+  'Password' =>
+    'Пароль',
+  'Choose an Emblem' =>
+    'Выберите Эмблему',
+  'Sign Up' =>
+    'Зарегистрироваться',
+  'Register to play Capture The Flag here. Once you have registered, you will be logged in.' =>
+    'Зарегистрируйтесь, чтобы сыграть в Capture The Flag. Как только вы зарегистрировались, вы будете оставаться в системе.',
+  'Not Available' =>
+    'Недоступно',
+  'Team Registration will be open soon, stay tuned!' =>
+    'Регистрация Команды будет скоро открыта, оставайтесь на связи!',
+  'Try Again' =>
+    'Попробовать Снова',
+  'Select' =>
+    'Выбрать',
+  'Team Login' =>
+    'Вход для Команды',
+  'Please login here. If you have not registered, you may do so by clicking "Sign Up" below. ' =>
+    'Пожалуйста, войдите. Если вы не регистрировались, вы можете сделать это нажав "Зарегистрироваться" ниже.',
+  'Team Login will be open soon, stay tuned!' =>
+    'Вход для Команды будет скоро открыт, оставайтесь на связи!',
+  'ERROR' =>
+    'ОШИБКА',
+  'Start Over' =>
+    'Начать Заново',
+  'Window is too small' =>
+    'Окно слишком маленькое',
+  'For the best CTF experience, please make window size bigger.' =>
+    'Для наилучших ощущений от игры, пожалуйста, сделайте размер окна больше.',
+  'Thank you.' =>
+    'Спасибо.',
+  'Logout' =>
+    'Выйти',
+  'Registration' =>
+    'Регистрация',
+  'Play CTF' =>
+    'Сыграть в CTF',
+  'Rules' =>
+    'Правила',
+  //Translations for GameboardController
+  'Admin' =>
+    'Admin',
+  'ADMIN' =>
+    'ADMIN',
+  'Navigation' =>
+    'Навигация',
+  'View Mode' =>
+    'Режим Просмотра',
+  'View mode' =>
+    'Режим просмотра',
+  'Tutorial' =>
+    'Обучение',
+  'Scoreboard' =>
+    'Таблица',
+  'You' =>
+    'Вы',
+  'Others' =>
+    'Остальные',
+  'All' =>
+    'Все',
+  'Leaderboard' =>
+    'Лидеры',
+  'Announcements' =>
+    'Уведомления',
+  'Teams' =>
+    'Команды',
+  'Filter' =>
+    'Фильтр',
+  'Activity' =>
+    'Действие',
+  'Game Clock' =>
+    'Игровые Часы',
+  //Translations for AdminController
+  'Auto' =>
+    'Авто',
+  'All Categories' =>
+    'Все Категории',
+  'Open' =>
+    'Открыть',
+  'Tokenized' =>
+    'Токенизировано',
+  'Hour' =>
+    'Час',
+  'Hours' =>
+    'Часы',
+  'Used by' =>
+    'Используется',
+  'Used By' =>
+    'Используется',
+  'Available' =>
+    'Доступно',
+  'Registration Tokens' =>
+    'Токены для Регистрации',
+  'Create More' =>
+    'Создать Еще',
+  'Export Available' =>
+    'Экспортировать Доступные',
+  'Not started yet' =>
+    'Еще не началось',
+  'Configuration' =>
+    'Настройки',
+  'Tokens' =>
+    'Токены',
+  'Game Configuration' =>
+    'Настройки Игры',
+  'OK' =>
+    'OK',
+  'status_' =>
+    'статус_',
+  'On' =>
+    'Вкл',
+  'Off' =>
+    'Выкл',
+  'Player Names' =>
+    'Имена Игроков',
+  'Players Per Team' =>
+    'Игроков в Команде',
+  'Registration Type' =>
+    'Тип Регистрации',
+  'Strong Passwords' =>
+    'Сильные Пароли',
+  'Team Selection' =>
+    'Выбор Команды',
+  'Game' =>
+    'Игра',
+  'Scoring' =>
+    'Зарабатывание Очков',
+  'Progressive Cycle (s)' =>
+    'Последующий цикл (s)',
+  'Refresh Gameboard' =>
+    'Обновить Игровое Поле',
+  'Default Bonus' =>
+    'Бонус по Умолчанию',
+  'Bases Cycle (s)' =>
+    'Базовый Цикл (s)',
+  'Default Bonus Dec' =>
+    'Снижение Бонуса по Умолчанию',
+  'Timer' =>
+    'Таймер',
+  'Server Time' =>
+    'Серверное Время',
+  'Game Duration' =>
+    'Продолжительность Игры',
+  'Begin Time' =>
+    'Начало',
+  'Expected End Time' =>
+    'Ожидаемое Окончание',
+  'Language' =>
+    'Язык',
+  'DELETE' =>
+    'УДАЛИТЬ',
+  'Delete' =>
+    'Удалить',
+  'No Announcements' =>
+    'Нет Уведомлений',
+  'Game Controls' =>
+    'Управление Игрой',
+  'Write New Announcement here' =>
+    'Новое уведомление пишите здесь',
+  'Create' =>
+    'Создать',
+  'General' =>
+    'Общие',
+  'Back Up Database' =>
+    'Резервная Копия БД',
+  'Export Full Game' =>
+    'Экспортировать Игру',
+  'Import Full Game' =>
+    'Импортировать Игру',
+  'Import Teams' =>
+    'Импортировать Команды',
+  'Export Teams' =>
+    'Экспортировать Команды',
+  'Import Logos' =>
+    'Импортировать Логитипы',
+  'Export Logos' =>
+    'Экспортировать Логотипы',
+  'Import Levels' =>
+    'Импортировать Уровни',
+  'Export Levels' =>
+    'Экспортировать Уровни',
+  'Import Categories' =>
+    'Импоритровать Категории',
+  'Export Categories' =>
+    'Экспортировать Категории',
+  'Levels' =>
+    'Уровни',
+  'New Quiz Level' =>
+    'Новый Уровень Викторины',
+  'Title' =>
+    'Название',
+  'Question' =>
+    'Вопрос',
+  'Level title' =>
+    'Название уровня',
+  'Quiz question' =>
+    'Вопрос викторины',
+  'Country' =>
+    'Государство',
+  'Answer' =>
+    'Ответ',
+  'Points' =>
+    'Очки',
+  'Hint' =>
+    'Подсказка',
+  'Hint Penalty' =>
+    'Штраф за Подсказку',
+  'EDIT' =>
+    'РЕДАКТИРОВАТЬ',
+  'All Quiz Levels' =>
+    'Все Уровни Викторины',
+  'Filter By:' =>
+    'Отфильтровать По:',
+  'All Status' =>
+    'Статус Всего',
+  'Enabled' =>
+    'Включено',
+  'Disabled' =>
+    'Выключено',
+  'Quiz Level' =>
+    'Уровень Викторины',
+  'Show Answer' =>
+    'Показать Ответ',
+  'Bonus' =>
+    'Бонус',
+  '-Dec' =>
+    '-Уменьшение',
+  'Save' =>
+    'Сохранить',
+  'Quiz Management' =>
+    'Управление Викториной',
+  'Add Quiz Level' =>
+    'Добавить Уровень Викторины',
+  'New Flag Level' =>
+    'Новый Уровень Флага',
+  'Description' =>
+    'Описание',
+  'Level description' =>
+    'Описание уровня',
+  'Category' =>
+    'Категория',
+  'Flag' =>
+    'Флаг',
+  'flag' =>
+    'флаг',
+  'All Flag Levels' =>
+    'Все Уровни с Флагом',
+  'New Attachment:' =>
+    'Новое Вложение:',
+  'Attachment' =>
+    'Вложение',
+  'Link' =>
+    'Ссылка',
+  'New Link:' =>
+    'Новая Сылка:',
+  'Flag Level' =>
+    'Уровень Флага',
+  'Categories' =>
+    'Категории',
+  '+ Attachment' =>
+    '+ Вложение',
+  '+ Link' =>
+    '+ Ссылка',
+  'Flags Management' =>
+    'Управление Флагами',
+  'Add Flag Level' =>
+    'Добавить Уровень Флага',
+  'New Base Level' =>
+    'Новый Уровень Базы',
+  'Keep Points' =>
+    'Очки Удержания',
+  'Capture points' =>
+    'Очки Захвата',
+  'All Base Levels' =>
+    'Все Уровни Базы',
+  'Base Level' =>
+    'Уровень Базы',
+  'Bases Management' =>
+    'Управление Базами',
+  'Add Base Level' =>
+    'Добавить Уровень Базы',
+  'New Category' =>
+    'Новая категория',
+  'Category: ' =>
+    'Категория: ',
+  'Categories Management' =>
+    'Управление Категориями',
+  'Add Category' =>
+    'Добавить Категорию',
+  'All Countries' =>
+    'Все Государства',
+  'In Use' =>
+    'Используется',
+  'In use' =>
+    'Используется',
+  'Not Used' =>
+    'Не Используется',
+  'Yes' =>
+    'Да',
+  'No' =>
+    'Нет',
+  'ISO Code' =>
+    'Код ISO',
+  'Countries Management' =>
+    'Управление Государствами',
+  'No Team Names' =>
+    'Нет Имен Команд',
+  'time' =>
+    'время',
+  'type' =>
+    'тип',
+  'pts' =>
+    'очки',
+  'Level' =>
+    'Уровень',
+  'level' =>
+    'уровень',
+  'No Scores' =>
+    'Нет Очков',
+  'Attempt' =>
+    'Попытка',
+  'No Failures' =>
+    'Нет Ошибок',
+  'Team' =>
+    'Команда',
+  'team' =>
+    'команда',
+  'Names' =>
+    'Имена',
+  'Scores' =>
+    'Очки',
+  'Failures' =>
+    'Неудачи',
+  'New Team' =>
+    'Новая Команда',
+  'Team Logo' =>
+    'Логотип Команды',
+  'Selected Logo:' =>
+    'Выбранный Логотип:',
+  'Select Logo' =>
+    'Выбрать Логотип',
+  'All Teams' =>
+    'Все Команды',
+  'Protected' =>
+    'Защищено',
+  'Score' =>
+    'Счет',
+  'Change Password' =>
+    'Изменить Пароль',
+  'Admin Level' =>
+    'Уровень Администратора',
+  'Visibility' =>
+    'Видимость',
+  'Team Management' =>
+    'Управление Командой',
+  'Add Team' =>
+    'Добавить Команду',
+  'None' =>
+    'Ничего',
+  'Logo Name' =>
+    'Название Логотипа',
+  'Logo Management' =>
+    'Управление Логотипом',
+  'Session' =>
+    'Сессия',
+  'Cookie' =>
+    'Cookie',
+  'Creation Time' =>
+    'Время Создания',
+  'Last Access' =>
+    'Последний Доступ',
+  'Data' =>
+    'Данные',
+  'Sessions' =>
+    'Сессии',
+  'entry' =>
+    'запись',
+  'No Entries' =>
+    'Нет Записей',
+  'Game Logs' =>
+    'Логи Игры',
+  'Game Logs Timeline' =>
+    'Логи Игры по Времени',
+  'End Game' =>
+    'Завершить Игру',
+  'Begin Game' =>
+    'Начать Игру',
+  'Game Admin' =>
+    'Администратор Игры',
+  'Controls' =>
+    'Управление',
+  'Quiz' =>
+    'Викторина',
+  'Flags' =>
+    'Флаги',
+  'Bases' =>
+    'Базы',
+  'Countries' =>
+    'Государства',
+  'Logos' =>
+    'Логотипы',
+  //Translations for inc/* and inc/gameboard/*
+  'captured' =>
+    'захвачено',
+  'Status' =>
+    'Статус',
+  'Completed' =>
+    'Завершено',
+  'Remaining' =>
+    'Остается',
+  'Start' =>
+    'Начало',
+  'End' =>
+    'Конец',
+  'Rank' =>
+    'Ранг',
+  'pts' =>
+    'очк', //points
+  'Your Rank' =>
+    'Ваш Ранг',
+  'Your Score' =>
+    'Ваш Счет',
+  'Everyone' =>
+    'Все',
+  'Your Team' =>
+    'Ваша Команда',
+  'Captured' =>
+    'Захвачено',
+  'Initiating' =>
+    'Ознакомление',
+  'run : > boot_sequence' =>
+    'run : > boot_sequence',
+  'Extracting' =>
+    'Извлечение',
+  //Translations for Utils.php's time_ago() function
+  'just now' =>
+    'только что',
+  'd' =>
+    'день', //day
+  'hr' =>
+    'час', //hour
+  'min' =>
+    'минута', //minute
+  'sec' =>
+    'секунда', //second
+  'ds' =>
+    'дней', //days
+  'hrs' =>
+    'часов', //hours
+  'mins' =>
+    'минут', //minutes
+  'secs' =>
+    'секунд', //seconds
+  'ago' =>
+    'назад',
+  //Translations for ModalControllers
+  'begin_' =>
+    'начать_',
+  'Are you sure you want to kick off the game? Logs will be cleared and progressive scoreboard will start' =>
+    'Вы уверены, что хотите начать игру? Логи будут очищены, и начнется последовательное начисление очков',
+  'end_' =>
+    'конец_',
+  'Are you sure you want to finish the current game?' =>
+    'Вы уверены, что хотите завершить текущую игру?',
+  'Are you sure you want to logout from the game?' =>
+    'Вы уверены, что хотите выйти из игры?',
+  'Saved' =>
+    'Сохранено',
+  'All changes have been successfully saved.' =>
+    'Все изменения успешно сохранены.',
+  'Error' =>
+    'Ошибка',
+  'Sorry your form was not saved. Please correct the all errors and save again.' =>
+    'Извините, ваша форма не была сохранена. Пожалуйста, исправьте все ошибки и сохраните еще раз.',
+  'cancel_' =>
+    'отмена_',
+  'Are you sure you want to cancel? You have unsaved changes that will be reverted.' =>
+    'Вы уверены, что хотите отменить? У вас есть несохраненные изменения, которые будут утрачены.',
+  'choose_logo' =>
+    'выбрать_лого',
+  'captured_' =>
+    'захвачено_',
+  'flag_owner_' =>
+    'флаг_владелец_',
+  'INACTIVE' =>
+    'НЕАКТИВНО',
+  'PTS' =>
+    'ОЧК',
+  'category' =>
+    'категория',
+  'capture_' =>
+    'захват_',
+  'Insert your answer' =>
+    'Введите свой ответ',
+  'Request Hint' =>
+    'Попросить Подсказку',
+  'Submit' =>
+    'Подать',
+  'hint_' =>
+    'подсказка_',
+  'first_capture' =>
+    'первый_захват',
+  'completed_by' =>
+    'выполнено',
+  'scoreboard_' =>
+    'таблица_',
+  'filter_' =>
+    'фильтр_',
+  'rank_' =>
+    'ранг_',
+  'team_name_' =>
+    'имя_команды_',
+  'quiz_pts_' =>
+    'викторина_очки_',
+  'flag_pts_' =>
+    'флаг_очки_',
+  'base_pts_' =>
+    'база_очки_',
+  'total_pts_' =>
+    'всего_очки_',
+  'team_' =>
+    'команда_',
+  'team_members' =>
+    'члены_команды',
+  'base_pts' =>
+    'база_очки',
+  'quiz_pts' =>
+    'викторина_очки',
+  'flag_pts' =>
+    'флаг_очки',
+  'total_pts' =>
+    'всего_очки',
+  'Tool bars are located on all edges of the gameboard. Tap a category to expand and close each tool bar.' =>
+    'Тулбары находятся на всех краях таблицы. Нажмите на категорию, чтобы развернуть и свернуть каждый тулбар.',
+  'Tool_Bars' =>
+    'Тулбары',
+  'Tap the "Game Clock" to keep track of time during gameplay. Don’t let time get the best of you.' =>
+    'Нажмите на "Игровые Часы", чтобы следить за временем во время игры. Не позволяйте времени застать себя врасплох.',
+  'Game_Clock' =>
+    'Игровые_Часы',
+  'Countries marked with an ' =>
+    'Страны, отмеченные ',
+  'are captured by you.' =>
+    ' захваченные вами.',
+  ' are owned by others.' =>
+    ' принадлежат другим.',
+  'Captures' =>
+    'Захваты',
+  'Tap Plus[+] to Zoom In. Tap Minus[-] to Zoom Out.' =>
+    'Нажмите Плюс[+], чтобы Увеличить масштаб. Нажмите Минус[-], чтобы Уменьшить масштаб.',
+  'Click and Drag to move left, right, up and down.' =>
+    'Нажмите и Перетащите, чтобы передвинуть влево, вправо, наверх или вниз.',
+  'Zoom' =>
+    'Масштабировать',
+  'Tap Forward Slash [/] to activate computer commands. A list of commands can be found under "Rules".' =>
+    'Используйте Слэш [/], чтобы активировать компьютерные команды. Список команд может быть найден в "Правилах".',
+  'Command_Line' =>
+    'Командная_Строка',
+  'Click "Nav" to access main navigation links like Rules of Play, Registration, Blog, Jobs & more.' =>
+    'Нажмите на "Навигацию", чтобы получить основные навигационные ссылки вроде Правил Игры, Регистрации, Блога, Вакансий и проч.',
+  'Track your competition by clicking "scorboard" to access real-time game statistics and graphs.' =>
+    'Следите за своим соревнованием через "таблицу", чтобы получать статистику игры и графики в режиме реального времени.',
+  'Have fun, be the best and conquer the world.' =>
+    'Насладитесь игрой, будьте лучшими и захватите мир.',
+  'Game_On' =>
+    'Игра_Вкл',
+  'tutorial_' =>
+    'обучение_',
+  'Next' =>
+    'Следующий',
+  'Skip to play' =>
+    'Пропустить',
+  'Powered By Facebook' =>
+    'Powered By Facebook',
+);


### PR DESCRIPTION
This adds some kind of Russian translation. The thing is, there's still some work to be done because Russian language is not that flexible and it's a hit and miss trying to translate one or two words without a context. It also distinguishes between a verb and a noun, as well as contains cases and conjugations. So this needs to be polished by other community members who can launch the platform and play with it, fixing misused translations. Although I didn't have any similar program translating experience it seems to me that this is not the best way to provide localization because it's so error-prone. However, I don't have any alternative solution to suggest.
