### PR TITLE
Fix progressive scoreboard and bases

### DIFF
--- a/src/scripts/bases.php
+++ b/src/scripts/bases.php
@@ -1,6 +1,12 @@
 <?hh
 
-require_once ('/var/www/fbctf/vendor/autoload.php');
+require_once('/var/www/fbctf/src/Db.php');
+require_once('/var/www/fbctf/src/Utils.php');
+require_once('/var/www/fbctf/src/models/Model.php');
+require_once('/var/www/fbctf/src/models/Importable.php');
+require_once('/var/www/fbctf/src/models/Exportable.php');
+require_once('/var/www/fbctf/src/models/Level.php');
+require_once('/var/www/fbctf/src/models/Configuration.php');
 
 $conf_game = \HH\Asio\join(Configuration::gen('game'));
 while ($conf_game->getValue() === '1') {

--- a/src/scripts/progressive.php
+++ b/src/scripts/progressive.php
@@ -1,6 +1,10 @@
 <?hh
 
-require_once ('/var/www/fbctf/vendor/autoload.php');
+require_once('/var/www/fbctf/src/Db.php');
+require_once('/var/www/fbctf/src/Utils.php');
+require_once('/var/www/fbctf/src/models/Model.php');
+require_once('/var/www/fbctf/src/models/Configuration.php');
+require_once('/var/www/fbctf/src/models/Progressive.php');
 
 while (\HH\Asio\join(Progressive::genGameStatus())) {
   \HH\Asio\join(Progressive::genTake());


### PR DESCRIPTION
When a new game is started, `src/models/Progressive.php` starts `scripts/progressive.php` in the background by passing it as a parameter to hhvm from the shell. The file `scripts/progressive.php` includes `autoload.php`, which initiates a chain of inclusions, most of which use `$_SERVER['DOCUMENT_ROOT']` to determine the file path. Since the `$_SERVER` variable is not available when hhvm is called from the shell, the shell command errors out, and the progressive scoreboard doesn't work. The workaround is to manually include the required php files for `scripts/progressive.php` to work.

It seems to me that this is related to #165. Can anyone please reject my analysis by showing that the progressive scoreboard works for them with the latest code?

New open issue: the background process is not killed when the game is stopped.
