### PR TITLE
Disallow running scripts from web

### DIFF
--- a/src/scripts/bases.php
+++ b/src/scripts/bases.php
@@ -1,5 +1,10 @@
 <?hh
 
+if (php_sapi_name() !== 'cli') {
+  http_response_code(405); // method not allowed
+  exit(0);
+}
+
 require_once ('/var/www/fbctf/vendor/autoload.php');
 
 $conf_game = \HH\Asio\join(Configuration::gen('game'));

--- a/src/scripts/progressive.php
+++ b/src/scripts/progressive.php
@@ -1,5 +1,10 @@
 <?hh
 
+if (php_sapi_name() !== 'cli') {
+  http_response_code(405); // method not allowed
+  exit(0);
+}
+
 require_once ('/var/www/fbctf/vendor/autoload.php');
 
 while (\HH\Asio\join(Progressive::genGameStatus())) {


### PR DESCRIPTION
Runs fine from terminal, but:

```
fredemmott-mbp1:extra fredemmott$ curl -kI https://localhost/scripts/bases.php
HTTP/1.1 405 Method Not Allowed
Server: nginx
Date: Wed, 05 Oct 2016 16:49:58 GMT
Content-Type: text/html
Connection: keep-alive
X-Powered-By: HHVM/3.14.5
Vary: Accept-Encoding
```