### PR TITLE
Use the correct CSS selector to find out if names are required

### DIFF
--- a/src/static/js/fb-ctf.js
+++ b/src/static/js/fb-ctf.js
@@ -2289,7 +2289,7 @@ function setupInputListeners() {
     $body = $('body');
 
     $('#login_button').click(Index.loginTeam);
-    var names_required = $('#register_names').length > 0;
+    var names_required = $('input[name=action]').val() === 'register_names';
     if (names_required) {
       $('#register_button').click(Index.registerNames);
     } else {


### PR DESCRIPTION
The selector `#register_names` doesn't seem to be in the DOM.

This change replaces that check with one that checks for the value of the hidden input named `action`. If that value is `register_names` we make sure to collect the names and add them to the AJAX response to the server.

Fixes #86
