### PR TITLE
Don't pretty print DataController JSON data

### DIFF
--- a/src/data/controller.php
+++ b/src/data/controller.php
@@ -6,6 +6,6 @@ abstract class DataController {
 
   public function jsonSend(mixed $data): void {
     header('Content-Type: application/json');
-    print json_encode($data, JSON_PRETTY_PRINT);
+    print json_encode($data);
   }
 }


### PR DESCRIPTION
Because it can (and does) quite readily more than double the size of the data being sent, and is completely unnecessary.