### PR TITLE
Major Reduction of MySQL Queries

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -160,6 +160,7 @@ CREATE TABLE `sessions` (
   `team_id` int(11) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   `last_access_ts` timestamp NOT NULL,
+  `last_page_access` text NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -160,6 +160,7 @@ CREATE TABLE `sessions` (
   `team_id` int(11) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   `last_access_ts` timestamp NOT NULL,
+   `last_page_access` text NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -160,7 +160,7 @@ CREATE TABLE `sessions` (
   `team_id` int(11) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   `last_access_ts` timestamp NOT NULL,
-   `last_page_access` text NOT NULL,
+  `last_page_access` text NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/src/Router.php
+++ b/src/Router.php
@@ -100,7 +100,6 @@ class Router {
 
   // Check to see if the request is going through the router
   public static function isRequestRouter(): bool {
-    if (self::getRequestedPage() == "index") return false;
-    else return true;
+    return self::getRequestedPage() != "index";
   }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -84,4 +84,23 @@ class Router {
         throw new NotFoundRedirectException();
     }
   }
+
+  public static function getRequestedPage(): string {
+    $page = idx(Utils::getGET(), 'page') ?: idx(Utils::getGET(), 'p');
+    if (!is_string($page)) {
+      $page = 'index';
+    }
+
+    return strval($page);
+  }
+
+  public static function isRequestAjax(): bool {
+    return Utils::getGET()->get('ajax') === 'true';
+  }
+
+  // Check to see if the request is going through the router
+  public static function isRequestRouter(): bool {
+    if (self::getRequestedPage() == "index") return false;
+    else return true;
+  }
 }

--- a/src/SessionUtils.php
+++ b/src/SessionUtils.php
@@ -140,5 +140,4 @@ class SessionUtils {
     /* HH_IGNORE_ERROR[2050] */
     return must_have_string($_SESSION, 'csrf_token');
   }
-
 }

--- a/src/SessionUtils.php
+++ b/src/SessionUtils.php
@@ -54,13 +54,8 @@ class SessionUtils {
   }
 
   public function read(string $cookie): string {
-    $session_exists = \HH\Asio\join(Session::genSessionExist($cookie));
-    if ($session_exists) {
-      $session = \HH\Asio\join(Session::gen($cookie));
-      return $session->getData();
-    } else {
-      return '';
-    }
+    $session = \HH\Asio\join(Session::genSessionDataIfExist($cookie));
+    return $session;
   }
 
   public function write(string $cookie, string $data): bool {
@@ -145,4 +140,5 @@ class SessionUtils {
     /* HH_IGNORE_ERROR[2050] */
     return must_have_string($_SESSION, 'csrf_token');
   }
+
 }

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -205,7 +205,7 @@ class AdminController extends Controller {
     $tokens = await Token::genAllTokens();
     foreach ($tokens as $token) {
       if ($token->getUsed()) {
-        $team = await Team::genTeam($token->getTeamId());
+        $team = await MultiTeam::genTeam($token->getTeamId());
         $token_status =
           <span class="highlighted--red">
             {tr('Used by')} {$team->getName()}
@@ -2973,7 +2973,7 @@ class AdminController extends Controller {
     $all_logos = await Logo::genAllLogos();
     foreach ($all_logos as $logo) {
       $xlink_href = '#icon--badge-'.$logo->getName();
-      $using_logo = await Team::genWhoUses($logo->getName());
+      $using_logo = await MultiTeam::genWhoUses($logo->getName());
       $current_use = (count($using_logo) > 0) ? tr('Yes') : tr('No');
       if ($logo->getEnabled()) {
         $highlighted_action = 'disable_logo';
@@ -3068,7 +3068,7 @@ class AdminController extends Controller {
     $all_sessions = await Session::genAllSessions();
     foreach ($all_sessions as $session) {
       $session_id = 'session_'.strval($session->getId());
-      $team = await Team::genTeam($session->getTeamId());
+      $team = await MultiTeam::genTeam($session->getTeamId());
       $adminsections->appendChild(
         <section class="admin-box section-locked">
           <form class="session_form" name={$session_id}>
@@ -3111,6 +3111,16 @@ class AdminController extends Controller {
                   <span class="highlighted">
                     <label class="admin-label">
                       {time_ago($session->getLastAccessTs())}
+                    </label>
+                  </span>
+                </div>
+              </div>
+              <div class="col col-1-3 col-pad">
+                <div class="form-el el--block-label el--full-text">
+                  <label class="admin-label">{tr('Last Page Access')}:</label>
+                  <span class="highlighted">
+                    <label class="admin-label">
+                      {$session->getLastPageAccess()}
                     </label>
                   </span>
                 </div>
@@ -3167,7 +3177,7 @@ class AdminController extends Controller {
           $log_entry =
             <span class="highlighted--red">{$gamelog->getEntry()}</span>;
         }
-        $team = await Team::genTeam($gamelog->getTeamId());
+        $team = await MultiTeam::genTeam($gamelog->getTeamId());
         $level = await Level::gen($gamelog->getLevelId());
         $country = await Country::gen($level->getEntityId());
         $level_str =

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -462,7 +462,7 @@ class IndexController extends Controller {
         $login_select = "on";
         $login_team = <select name="team_id" />;
         $login_team->appendChild(<option value="0">{tr('Select')}</option>);
-        $all_active_teams = await Team::genAllActiveTeams();
+        $all_active_teams = await MultiTeam::genAllActiveTeams();
         foreach ($all_active_teams as $team) {
           error_log('Getting '.$team->getName());
           $login_team->appendChild(

--- a/src/controllers/ajax/AdminAjaxController.php
+++ b/src/controllers/ajax/AdminAjaxController.php
@@ -14,6 +14,7 @@ class AdminAjaxController extends AjaxController {
         'session_id' => FILTER_VALIDATE_INT,
         'cookie' => FILTER_SANITIZE_STRING,
         'data' => FILTER_UNSAFE_RAW,
+        'last_page_access' => FILTER_SANITIZE_STRING,
         'name' => FILTER_UNSAFE_RAW,
         'password' => FILTER_UNSAFE_RAW,
         'admin' => FILTER_VALIDATE_INT,

--- a/src/controllers/ajax/GameAjaxController.php
+++ b/src/controllers/ajax/GameAjaxController.php
@@ -61,6 +61,11 @@ class GameAjaxController extends AjaxController {
             );
             // Update teams last score
             await Team::genLastScore(SessionUtils::sessionTeam());
+            //Invalidate score cache
+            MultiTeam::invalidateMCRecords('POINTS_BY_TYPE');
+            MultiTeam::invalidateMCRecords('LEADERBOARD');
+            MultiTeam::invalidateMCRecords('TEAMS_BY_LEVEL');
+            MultiTeam::invalidateMCRecords('TEAMS_FIRST_CAP');
             return Utils::ok_response('Success', 'game');
           } else {
             await FailureLog::genLogFailedScore(

--- a/src/controllers/modals/ScoreboardModalController.php
+++ b/src/controllers/modals/ScoreboardModalController.php
@@ -40,15 +40,15 @@ class ScoreboardModalController extends ModalController {
     $gameboard = await Configuration::gen('gameboard');
     if ($gameboard->getValue() === '1') {
       $rank = 1;
-      $leaderboard = await Team::genLeaderboard();
+      $leaderboard = await MultiTeam::genLeaderboard();
 
       foreach ($leaderboard as $team) {
         $team_id = 'fb-scoreboard--team-'.strval($team->getId());
         $color = '#'.substr(md5($team->getName()), 0, 6).';';
         $style = 'color: '.$color.'; background:'.$color.';';
-        $quiz = await Team::genPointsByType($team->getId(), 'quiz');
-        $flag = await Team::genPointsByType($team->getId(), 'flag');
-        $base = await Team::genPointsByType($team->getId(), 'base');
+        $quiz = await MultiTeam::genPointsByType($team->getId(), 'quiz');
+        $flag = await MultiTeam::genPointsByType($team->getId(), 'flag');
+        $base = await MultiTeam::genPointsByType($team->getId(), 'base');
         $scoreboard_tbody->appendChild(
           <tr>
             <td style="width: 10%;" class="el--radio">

--- a/src/data/command-line.php
+++ b/src/data/command-line.php
@@ -48,7 +48,7 @@ class CommandsController extends DataController {
     // List of active teams.
     $teams_results = array();
     $teams_key = "teams";
-    $all_visible_teams = await Team::genAllVisibleTeams();
+    $all_visible_teams = await MultiTeam::genAllVisibleTeams();
     foreach ($all_visible_teams as $team) {
       array_push($teams_results, $team->getName());
     }

--- a/src/data/country-data.php
+++ b/src/data/country-data.php
@@ -8,7 +8,7 @@ SessionUtils::enforceLogin();
 
 class CountryDataController extends DataController {
   public async function genGenerateData(): Awaitable<void> {
-    $my_team = await Team::genTeam(SessionUtils::sessionTeam());
+    $my_team = await MultiTeam::genTeam(SessionUtils::sessionTeam());
 
     $countries_data = (object) array();
 
@@ -79,14 +79,14 @@ class CountryDataController extends DataController {
 
       // All teams that have completed this level
       $completed_by = array();
-      $completed_level = await Team::genCompletedLevel($level->getId());
+      $completed_level = await MultiTeam::genCompletedLevel($level->getId());
       foreach ($completed_level as $c) {
         array_push($completed_by, $c->getName());
       }
 
       // Who is the first owner of this level
       if ($completed_level) {
-        $owner = await Team::genFirstCapture($level->getId());
+        $owner = await MultiTeam::genFirstCapture($level->getId());
         $owner = $owner->getName();
       } else {
         $owner = 'Uncaptured';

--- a/src/data/leaderboard.php
+++ b/src/data/leaderboard.php
@@ -17,8 +17,8 @@ class LeaderboardDataController extends DataController {
       exit(1);
     }
 
-    $leaders = await Team::genLeaderboard();
-    $my_team = await Team::genTeam(SessionUtils::sessionTeam());
+    $leaders = await MultiTeam::genLeaderboard();
+    $my_team = await MultiTeam::genTeam(SessionUtils::sessionTeam());
     $my_rank = await Team::genMyRank(SessionUtils::sessionTeam());
     $my_team_data = (object) array(
       'badge' => $my_team->getLogo(),

--- a/src/data/map-data.php
+++ b/src/data/map-data.php
@@ -46,7 +46,7 @@ class MapDataController extends DataController {
         } else if ($other_previous_score) {
           $captured_by = 'opponent';
           $completed_by =
-            await Team::genCompletedLevel($country_level->getId());
+            await MultiTeam::genCompletedLevel($country_level->getId());
           $data_captured = '';
           foreach ($completed_by as $c) {
             $data_captured .= ' '.$c->getName();

--- a/src/data/scores.php
+++ b/src/data/scores.php
@@ -10,7 +10,7 @@ class ScoresDataController extends DataController {
   public async function genGenerateData(): Awaitable<void> {
     $data = array();
 
-    $leaderboard = await Team::genLeaderboard();
+    $leaderboard = await MultiTeam::genLeaderboard();
     foreach ($leaderboard as $team) {
       $values = array();
       $i = 1;

--- a/src/data/teams.php
+++ b/src/data/teams.php
@@ -9,7 +9,7 @@ SessionUtils::enforceLogin();
 class TeamDataController extends DataController {
   public async function genGenerateData(): Awaitable<void> {
     $rank = 1;
-    $leaderboard = await Team::genLeaderboard();
+    $leaderboard = await MultiTeam::genLeaderboard();
     $teams_data = (object) array();
 
     // If refresing is disabled, exit
@@ -20,9 +20,9 @@ class TeamDataController extends DataController {
     }
 
     foreach ($leaderboard as $team) {
-      $base = await Team::genPointsByType($team->getId(), 'base');
-      $quiz = await Team::genPointsByType($team->getId(), 'quiz');
-      $flag = await Team::genPointsByType($team->getId(), 'flag');
+      $base = await MultiTeam::genPointsByType($team->getId(), 'base');
+      $quiz = await MultiTeam::genPointsByType($team->getId(), 'quiz');
+      $flag = await MultiTeam::genPointsByType($team->getId(), 'flag');
 
       $team_data = (object) array(
         'badge' => $team->getLogo(),

--- a/src/inc/gameboard/modules/leaderboard-viewmode.php
+++ b/src/inc/gameboard/modules/leaderboard-viewmode.php
@@ -8,7 +8,7 @@ class LeaderboardModuleViewController {
     $leaderboard_ul = <ul></ul>;
 
     $rank = 1;
-    $leaderboard = await Team::genLeaderboard();
+    $leaderboard = await MultiTeam::genLeaderboard();
     foreach ($leaderboard as $team) {
       $xlink_href = '#icon--badge-'.$team->getLogo();
       $leaderboard_ul->appendChild(

--- a/src/inc/gameboard/modules/leaderboard.php
+++ b/src/inc/gameboard/modules/leaderboard.php
@@ -11,13 +11,13 @@ class LeaderboardModuleController {
     await tr_start();
     $leaderboard_ul = <ul></ul>;
 
-    $my_team = await Team::genTeam(SessionUtils::sessionTeam());
+    $my_team = await MultiTeam::genTeam(SessionUtils::sessionTeam());
     $my_rank = await Team::genMyRank(SessionUtils::sessionTeam());
 
     // If refresing is enabled, do the needful
     $gameboard = await Configuration::gen('gameboard');
     if ($gameboard->getValue() === '1') {
-      $leaders = await Team::genLeaderboard();
+      $leaders = await MultiTeam::genLeaderboard();
       $rank = 1;
       $l_max = (count($leaders) > 5) ? 5 : count($leaders);
       for ($i = 0; $i < $l_max; $i++) {

--- a/src/inc/gameboard/modules/teams.php
+++ b/src/inc/gameboard/modules/teams.php
@@ -9,7 +9,7 @@ SessionUtils::enforceLogin();
 class TeamModuleController {
   public async function genRender(): Awaitable<:xhp> {
     await tr_start();
-    $leaderboard = await Team::genLeaderboard();
+    $leaderboard = await MultiTeam::genLeaderboard();
     $rank = 1;
 
     $list = <ul class="grid-list"></ul>;

--- a/src/language/lang_bp.php
+++ b/src/language/lang_bp.php
@@ -453,6 +453,8 @@ $translations = array(
     'Tempo de Criação',
   'Last Access' =>
     'Último Acesso',
+  'Last Page Access' =>
+    'Última página de acesso a',
   'Data' =>
     'Dados',
   'Sessions' =>

--- a/src/language/lang_cat.php
+++ b/src/language/lang_cat.php
@@ -453,6 +453,8 @@ $translations = array(
     'Creation Time',
   'Last Access' =>
     'Últim Acces',
+  'Last Page Access' =>
+    'Darrera Pàgina d\'Accés',
   'Data' =>
     'Dades',
   'Sessions' =>

--- a/src/language/lang_en.php
+++ b/src/language/lang_en.php
@@ -453,6 +453,8 @@ $translations = array(
     'Creation Time',
   'Last Access' =>
     'Last Access',
+  'Last Page Access' =>
+    'Last Page Access',
   'Data' =>
     'Data',
   'Sessions' =>

--- a/src/language/lang_es.php
+++ b/src/language/lang_es.php
@@ -437,6 +437,8 @@ $translations = array(
     'Tiempo de Creación',
   'Last Access' =>
     'Último Acceso',
+  'Last Page Access' =>
+    'Última Página de Acceso',
   'Data' =>
     'Datos',
   'Sessions' =>

--- a/src/language/lang_hu.php
+++ b/src/language/lang_hu.php
@@ -437,6 +437,8 @@ $translations = array(
     'Létrehozás ideje',
   'Last Access' =>
     'Legutóbbi aktivitás',
+  'Last Page Access' =>
+    'Utolsó oldal Access',
   'Data' =>
     'Adat',
   'Sessions' =>

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -843,7 +843,7 @@ class Level extends Model implements Importable, Exportable {
           }
 
           // Make sure team has enough points to pay
-          $team = await Team::genTeam($team_id);
+          $team = await MultiTeam::genTeam($team_id);
           if ($team->getPoints() < $penalty) {
             return null;
           }

--- a/src/models/MultiTeam.php
+++ b/src/models/MultiTeam.php
@@ -1,0 +1,211 @@
+<?hh // strict
+
+class MultiTeam extends Team {
+
+  private static Map<int, Team> $all_teams = Map {};
+  private static array<Team> $team_leaderboard = [];
+  private static Map<int, Map<string, int>> $team_points_by_type = Map {};
+  private static array<Team> $all_active_teams = [];
+  private static array<Team> $all_visible_teams = [];
+  private static Map<string, array<Team>> $teams_by_logo = Map {};
+  private static Map<int, array<Team>> $teams_by_completed_level = Map {};
+  private static Map<int, Team> $first_team_captured_by_level = Map {};
+  
+  private static function setAllTeams(Map<int, Team> $all_teams): void {
+  	self::$all_teams = $all_teams;
+  }
+  
+  private static function setLeaderboard(array<Team> $team_leaderboard): void {
+    self::$team_leaderboard = $team_leaderboard;
+  }
+
+  private static function setPointsByType(Map<int, Map<string, int>> $team_points_by_type): void {
+    self::$team_points_by_type = $team_points_by_type;
+  }
+
+  private static function setAllActiveTeams(array<Team> $all_active_teams): void {
+  	self::$all_active_teams = $all_active_teams;
+  }
+  
+  private static function setAllVisibleTeams(array<Team> $all_visible_teams): void {
+    self::$all_visible_teams = $all_visible_teams;
+  }
+  
+  private static function setAllTeamsByLogo(Map<string, array<Team>> $teams_by_logo): void {
+  	self::$teams_by_logo = $teams_by_logo;
+  }
+  
+  private static function setTeamsByCompletedLevel(Map<int, array<Team>> $teams_by_completed_level): void {
+    self::$teams_by_completed_level = $teams_by_completed_level;
+  }
+  
+  private static function setFirstTeamCapturedByLevel(Map<int, Team> $first_team_captured_by_level): void {
+  	self::$first_team_captured_by_level = $first_team_captured_by_level;
+  }
+  
+  private static async function genTeamArrayFromDB(
+    string $query,
+  ): Awaitable<Vector<Map<string, string>>> {
+  	$db = await self::genDb();
+  	$result = await $db->query($query);
+  	
+  	return $result->mapRows();
+  }
+  
+  // All teams.
+  public static async function genAllTeamsCache(
+    bool $refresh = false,
+    ): Awaitable<Map<int, Team>> {
+      if ((count(self::$all_teams) === 0) || ($refresh)) {
+        $all_teams = Map {};
+        $teams = await self::genTeamArrayFromDB('SELECT * FROM teams');
+        foreach ($teams->items() as $team) {
+          $all_teams->add(Pair {intval($team->get("id")), Team::teamFromRow($team)});
+        }
+        self::setAllTeams($all_teams);
+       }
+    return self::$all_teams;
+  }
+  
+  public static async function genTeam(
+    int $team_id,
+    bool $refresh = false,
+  ): Awaitable<Team> {
+  	await self::genAllTeamsCache($refresh);
+    /* HH_IGNORE_ERROR[4110] */
+    return self::$all_teams->get($team_id);
+  }
+  
+  // Leaderboard order.
+  public static async function genLeaderboard(
+    bool $refresh = false,
+  ): Awaitable<array<Team>> {
+  	
+  	if ((count(self::$team_leaderboard) === 0) || ($refresh)) {
+  	  $team_leaderboard = array();
+      $teams = await self::genTeamArrayFromDB('SELECT * FROM teams WHERE active = 1 AND visible = 1 ORDER BY points DESC, last_score ASC');
+  	  foreach ($teams->items() as $team) {
+        $team_leaderboard[] = Team::teamFromRow($team);
+      }
+      self::setLeaderboard($team_leaderboard);
+  	}
+    return self::$team_leaderboard;
+  }
+  
+  // Get points by type.
+  public static async function genPointsByType(
+    int $team_id,
+    string $type,
+    bool $refresh = false,
+  ): Awaitable<int> {
+  	
+    if ((count(self::$team_points_by_type) === 0) || ($refresh)) {
+      $points_by_type = Map {};
+      $teams = await self::genTeamArrayFromDB('SELECT teams.id, scores_log.type, IFNULL(SUM(scores_log.points), 0) AS points FROM teams LEFT JOIN scores_log ON teams.id = scores_log.team_id GROUP BY teams.id, scores_log.type');
+      foreach ($teams->items() as $team) {
+      	if ($team->get("type") !== null) {
+          if ($points_by_type->contains(intval($team->get("id")))) {
+            $type_pair = $points_by_type->get(intval($team->get("id")));
+            /* HH_IGNORE_ERROR[4064] */
+            $type_pair->add(Pair {$team->get("type"), intval($team->get("points"))});
+            $points_by_type->set(intval($team->get("id")), $type_pair);
+          } else {
+            $type_pair = Map {};
+            $type_pair->add(Pair {$team->get("type"), intval($team->get("points"))});
+            $points_by_type->add(Pair {intval($team->get("id")), $type_pair});
+          }
+        }
+      }
+      /* HH_IGNORE_ERROR[4110] */
+      self::setPointsByType(new Map($points_by_type));
+    }
+    /* HH_IGNORE_ERROR[4064] */
+    if ((array_key_exists(intval($team_id), self::$team_points_by_type)) && (self::$team_points_by_type->contains($team_id)) && (self::$team_points_by_type->get($team_id)->contains($type))) return intval(self::$team_points_by_type->get($team_id)->get($type));
+    else return intval(0);
+  }
+  
+  // All active teams.
+  public static async function genAllActiveTeams(
+    bool $refresh = false,
+  ): Awaitable<array<Team>> {
+  	
+    if ((count(self::$all_active_teams) === 0) || ($refresh)) {
+      $all_active_teams = array();
+      $teams = await self::genTeamArrayFromDB('SELECT * FROM teams WHERE active = 1 ORDER BY id');
+      foreach ($teams->items() as $team) {
+      	$all_active_teams[] = Team::teamFromRow($team);
+      }
+      self::setAllActiveTeams($all_active_teams);
+    }
+    return self::$all_active_teams;
+  }
+  
+  // All visible teams.
+  public static async function genAllVisibleTeams(
+    bool $refresh = false,
+  ): Awaitable<array<Team>> {
+
+    if ((count(self::$all_visible_teams) === 0) || ($refresh)) {
+      $all_visible_teams = array();
+      $teams = await self::genTeamArrayFromDB('SELECT * FROM teams WHERE visible = 1 AND active = 1 ORDER BY id');
+      foreach ($teams->items() as $team) {
+        $all_visible_teams[] = Team::teamFromRow($team);
+      }
+      self::setAllVisibleTeams($all_visible_teams);
+    }
+    return self::$all_visible_teams;
+  }
+  
+  // Retrieve how many teams are using one logo.
+  public static async function genWhoUses(
+    string $logo,
+    bool $refresh = false,
+  ): Awaitable<array<Team>> {
+    if ((count(self::$teams_by_logo) === 0) || ($refresh)) {
+      $db = await self::genDb();
+      $all_teams = await self::genAllTeamsCache();    
+      
+      $teams_by_logo = array();
+      foreach ($all_teams as $team) {
+        $teams_by_logo[$team->getLogo()][] = $team;
+      }
+      self::setAllTeamsByLogo(new Map($teams_by_logo));
+    }
+    /* HH_IGNORE_ERROR[4110] */
+    if ((count(self::$teams_by_logo) !== 0) && (array_key_exists($logo, self::$teams_by_logo))) return self::$teams_by_logo->get("$logo");
+    else return array();
+  }
+  
+  public static async function genCompletedLevel(
+    int $level_id,
+    bool $refresh = false,
+  ): Awaitable<array<Team>> {
+    if ((count(self::$teams_by_completed_level) === 0) || ($refresh)) {
+    	$teams_by_completed_level = array();
+      $teams = await self::genTeamArrayFromDB('SELECT scores_log.level_id, teams.* FROM teams LEFT JOIN scores_log ON teams.id = scores_log.team_id WHERE teams.visible = 1 AND teams.active = 1 AND level_id IS NOT NULL ORDER BY scores_log.ts');
+      foreach ($teams->items() as $team) {
+      	$teams_by_completed_level[intval($team->get("level_id"))][] = Team::teamFromRow($team);
+      }
+      self::setTeamsByCompletedLevel(new Map($teams_by_completed_level));
+  	}
+  	/* HH_IGNORE_ERROR[4110] */
+  	if (self::$teams_by_completed_level->contains($level_id)) return self::$teams_by_completed_level->get($level_id);
+  	else return array();
+  }
+  
+  public static async function genFirstCapture(
+    int $level_id,
+    bool $refresh = false,
+  ): Awaitable<Team> {
+    if ((count(self::$first_team_captured_by_level) === 0) || ($refresh)) {
+    	$first_team_captured_by_level = array();
+      $teams = await self::genTeamArrayFromDB('SELECT * FROM teams LEFT JOIN scores_log ON teams.id = scores_log.team_id WHERE scores_log.ts IN (SELECT MIN(scores_log.ts) FROM scores_log GROUP BY scores_log.level_id)');
+      foreach ($teams->items() as $team) {
+      	$first_team_captured_by_level[intval($team->get("level_id"))] = Team::teamFromRow($team);
+      }
+      self::setFirstTeamCapturedByLevel(new Map($first_team_captured_by_level));
+    }
+    /* HH_IGNORE_ERROR[4110] */
+    return self::$first_team_captured_by_level->get($level_id);
+  }
+}

--- a/src/models/MultiTeam.php
+++ b/src/models/MultiTeam.php
@@ -2,47 +2,50 @@
 
 class MultiTeam extends Team {
 
-  private static Map<int, Team> $all_teams = Map {};
-  private static array<Team> $team_leaderboard = [];
-  private static Map<int, Map<string, int>> $team_points_by_type = Map {};
-  private static array<Team> $all_active_teams = [];
-  private static array<Team> $all_visible_teams = [];
-  private static Map<string, array<Team>> $teams_by_logo = Map {};
-  private static Map<int, array<Team>> $teams_by_completed_level = Map {};
-  private static Map<int, Team> $first_team_captured_by_level = Map {};
-  
-  private static function setAllTeams(Map<int, Team> $all_teams): void {
-  	self::$all_teams = $all_teams;
-  }
-  
-  private static function setLeaderboard(array<Team> $team_leaderboard): void {
-    self::$team_leaderboard = $team_leaderboard;
+  const int MC_EXPIRE = 60;
+  const string MC_KEY = 'multiteam:';
+
+  private static Map<string, string> $MC_KEYS = Map{
+    "ALL_TEAMS" => "all_teams",
+    "LEADERBOARD" => "leaderboard_teams",
+    "POINTS_BY_TYPE" => "points_by_type",
+    "ALL_ACTIVE_TEAMS" => "active_teams",
+    "ALL_VISIBLE_TEAMS" => "visible_teams",
+    "TEAMS_BY_LOGO" => "logo_teams",
+    "TEAMS_BY_LEVEL" => "level_teams",
+    "TEAMS_FIRST_CAP" => "capture_teams",
+  };
+
+  private static function setMCRecords(
+    string $key,
+    mixed $records
+  ): void {
+    $mc = self::getMc();
+    $mc->set(self::MC_KEY . self::$MC_KEYS->get($key), $records, self::MC_EXPIRE);
   }
 
-  private static function setPointsByType(Map<int, Map<string, int>> $team_points_by_type): void {
-    self::$team_points_by_type = $team_points_by_type;
+  private static function getMCRecords(
+    string $key,
+  ): mixed {
+    $mc = self::getMc();
+    $mc_result = $mc->get(self::MC_KEY . self::$MC_KEYS->get($key));
+    /* HH_IGNORE_ERROR[4110] */
+    return $mc_result;
   }
 
-  private static function setAllActiveTeams(array<Team> $all_active_teams): void {
-  	self::$all_active_teams = $all_active_teams;
+  public static function invalidateMCRecords(
+    ?string $key = null,
+  ): void {
+    $mc = self::getMc();
+    if (is_null($key)) {
+      foreach (self::$MC_KEYS as $name => $mc_key) {
+        $mc->delete(self::MC_KEY . self::$MC_KEYS->get($mc_key));
+      }
+    } else {
+      $mc->delete(self::MC_KEY . self::$MC_KEYS->get($key));
+    }
   }
-  
-  private static function setAllVisibleTeams(array<Team> $all_visible_teams): void {
-    self::$all_visible_teams = $all_visible_teams;
-  }
-  
-  private static function setAllTeamsByLogo(Map<string, array<Team>> $teams_by_logo): void {
-  	self::$teams_by_logo = $teams_by_logo;
-  }
-  
-  private static function setTeamsByCompletedLevel(Map<int, array<Team>> $teams_by_completed_level): void {
-    self::$teams_by_completed_level = $teams_by_completed_level;
-  }
-  
-  private static function setFirstTeamCapturedByLevel(Map<int, Team> $first_team_captured_by_level): void {
-  	self::$first_team_captured_by_level = $first_team_captured_by_level;
-  }
-  
+
   private static async function genTeamArrayFromDB(
     string $query,
   ): Awaitable<Vector<Map<string, string>>> {
@@ -51,55 +54,58 @@ class MultiTeam extends Team {
   	
   	return $result->mapRows();
   }
-  
+
   // All teams.
   public static async function genAllTeamsCache(
     bool $refresh = false,
-    ): Awaitable<Map<int, Team>> {
-      if ((count(self::$all_teams) === 0) || ($refresh)) {
-        $all_teams = Map {};
-        $teams = await self::genTeamArrayFromDB('SELECT * FROM teams');
-        foreach ($teams->items() as $team) {
-          $all_teams->add(Pair {intval($team->get("id")), Team::teamFromRow($team)});
-        }
-        self::setAllTeams($all_teams);
-       }
-    return self::$all_teams;
+  ): Awaitable<Map<int, Team>> {
+    $mc_result = self::getMCRecords('ALL_TEAMS');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+      $all_teams = Map {};
+      $teams = await self::genTeamArrayFromDB('SELECT * FROM teams');
+      foreach ($teams->items() as $team) {
+        $all_teams->add(Pair {intval($team->get("id")), Team::teamFromRow($team)});
+      }
+      self::setMCRecords('ALL_TEAMS', $all_teams);
+    }
+    /* HH_IGNORE_ERROR[4110] */
+    return self::getMCRecords('ALL_TEAMS');
   }
-  
+
   public static async function genTeam(
     int $team_id,
     bool $refresh = false,
   ): Awaitable<Team> {
-  	await self::genAllTeamsCache($refresh);
+    $all_teams = await self::genAllTeamsCache($refresh);
     /* HH_IGNORE_ERROR[4110] */
-    return self::$all_teams->get($team_id);
+    return $all_teams->get($team_id);
   }
-  
+
   // Leaderboard order.
   public static async function genLeaderboard(
     bool $refresh = false,
   ): Awaitable<array<Team>> {
-  	
-  	if ((count(self::$team_leaderboard) === 0) || ($refresh)) {
-  	  $team_leaderboard = array();
+    $mc_result = self::getMCRecords('LEADERBOARD');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+      $team_leaderboard = array();
       $teams = await self::genTeamArrayFromDB('SELECT * FROM teams WHERE active = 1 AND visible = 1 ORDER BY points DESC, last_score ASC');
   	  foreach ($teams->items() as $team) {
         $team_leaderboard[] = Team::teamFromRow($team);
       }
-      self::setLeaderboard($team_leaderboard);
+      self::setMCRecords('LEADERBOARD', $team_leaderboard);
   	}
-    return self::$team_leaderboard;
+    /* HH_IGNORE_ERROR[4110] */
+    return self::getMCRecords('LEADERBOARD');
   }
-  
+
   // Get points by type.
   public static async function genPointsByType(
     int $team_id,
     string $type,
     bool $refresh = false,
   ): Awaitable<int> {
-  	
-    if ((count(self::$team_points_by_type) === 0) || ($refresh)) {
+    $mc_result = self::getMCRecords('POINTS_BY_TYPE');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
       $points_by_type = Map {};
       $teams = await self::genTeamArrayFromDB('SELECT teams.id, scores_log.type, IFNULL(SUM(scores_log.points), 0) AS points FROM teams LEFT JOIN scores_log ON teams.id = scores_log.team_id GROUP BY teams.id, scores_log.type');
       foreach ($teams->items() as $team) {
@@ -116,96 +122,121 @@ class MultiTeam extends Team {
           }
         }
       }
-      /* HH_IGNORE_ERROR[4110] */
-      self::setPointsByType(new Map($points_by_type));
+      self::setMCRecords('POINTS_BY_TYPE', new Map($points_by_type));
     }
-    /* HH_IGNORE_ERROR[4064] */
-    if ((array_key_exists(intval($team_id), self::$team_points_by_type)) && (self::$team_points_by_type->contains($team_id)) && (self::$team_points_by_type->get($team_id)->contains($type))) return intval(self::$team_points_by_type->get($team_id)->get($type));
-    else return intval(0);
+    $team_points_by_type = self::getMCRecords('POINTS_BY_TYPE');
+    if (
+      /* HH_IGNORE_ERROR[4110] */
+      (array_key_exists(intval($team_id), $team_points_by_type)) &&
+      /* HH_IGNORE_ERROR[4062] */
+      ($team_points_by_type->contains($team_id)) &&
+      /* HH_IGNORE_ERROR[4062] */
+      ($team_points_by_type->get($team_id)->contains($type))
+    ) {
+      /* HH_IGNORE_ERROR[4062] */
+      return intval($team_points_by_type->get($team_id)->get($type));
+    } else {
+      return intval(0);
+    }
   }
-  
+
   // All active teams.
   public static async function genAllActiveTeams(
     bool $refresh = false,
   ): Awaitable<array<Team>> {
-  	
-    if ((count(self::$all_active_teams) === 0) || ($refresh)) {
+    $mc_result = self::getMCRecords('ALL_ACTIVE_TEAMS');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
       $all_active_teams = array();
       $teams = await self::genTeamArrayFromDB('SELECT * FROM teams WHERE active = 1 ORDER BY id');
       foreach ($teams->items() as $team) {
       	$all_active_teams[] = Team::teamFromRow($team);
       }
-      self::setAllActiveTeams($all_active_teams);
+      self::setMCRecords('ALL_ACTIVE_TEAMS', $all_active_teams);
     }
-    return self::$all_active_teams;
+    /* HH_IGNORE_ERROR[4110] */
+    return self::getMCRecords('ALL_ACTIVE_TEAMS');
   }
-  
+
   // All visible teams.
   public static async function genAllVisibleTeams(
     bool $refresh = false,
   ): Awaitable<array<Team>> {
-
-    if ((count(self::$all_visible_teams) === 0) || ($refresh)) {
+    $mc_result = self::getMCRecords('ALL_VISIBLE_TEAMS');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
       $all_visible_teams = array();
       $teams = await self::genTeamArrayFromDB('SELECT * FROM teams WHERE visible = 1 AND active = 1 ORDER BY id');
       foreach ($teams->items() as $team) {
         $all_visible_teams[] = Team::teamFromRow($team);
       }
-      self::setAllVisibleTeams($all_visible_teams);
+      self::setMCRecords('ALL_VISIBLE_TEAMS', $all_visible_teams);
     }
-    return self::$all_visible_teams;
+    /* HH_IGNORE_ERROR[4110] */
+    return self::getMCRecords('ALL_VISIBLE_TEAMS');
   }
-  
+
   // Retrieve how many teams are using one logo.
   public static async function genWhoUses(
     string $logo,
     bool $refresh = false,
   ): Awaitable<array<Team>> {
-    if ((count(self::$teams_by_logo) === 0) || ($refresh)) {
+    $mc_result = self::getMCRecords('TEAMS_BY_LOGO');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
       $db = await self::genDb();
-      $all_teams = await self::genAllTeamsCache();    
-      
+      $all_teams = await self::genAllTeamsCache();
       $teams_by_logo = array();
       foreach ($all_teams as $team) {
         $teams_by_logo[$team->getLogo()][] = $team;
       }
-      self::setAllTeamsByLogo(new Map($teams_by_logo));
+      self::setMCRecords('TEAMS_BY_LOGO', new Map($teams_by_logo));
     }
+    $teams_by_logo = self::getMCRecords('TEAMS_BY_LOGO');
     /* HH_IGNORE_ERROR[4110] */
-    if ((count(self::$teams_by_logo) !== 0) && (array_key_exists($logo, self::$teams_by_logo))) return self::$teams_by_logo->get("$logo");
-    else return array();
+    if ((count($teams_by_logo) !== 0) && (array_key_exists($logo, $teams_by_logo))) {
+      /* HH_IGNORE_ERROR[4062] */
+      return $teams_by_logo->get($logo);
+    } else {
+      return array();
+    }
   }
-  
+
   public static async function genCompletedLevel(
     int $level_id,
     bool $refresh = false,
   ): Awaitable<array<Team>> {
-    if ((count(self::$teams_by_completed_level) === 0) || ($refresh)) {
-    	$teams_by_completed_level = array();
+    $mc_result = self::getMCRecords('TEAMS_BY_LEVEL');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+      $teams_by_completed_level = array();
       $teams = await self::genTeamArrayFromDB('SELECT scores_log.level_id, teams.* FROM teams LEFT JOIN scores_log ON teams.id = scores_log.team_id WHERE teams.visible = 1 AND teams.active = 1 AND level_id IS NOT NULL ORDER BY scores_log.ts');
       foreach ($teams->items() as $team) {
-      	$teams_by_completed_level[intval($team->get("level_id"))][] = Team::teamFromRow($team);
+        $teams_by_completed_level[intval($team->get("level_id"))][] = Team::teamFromRow($team);
       }
-      self::setTeamsByCompletedLevel(new Map($teams_by_completed_level));
+      self::setMCRecords('TEAMS_BY_LEVEL', new Map($teams_by_completed_level));
   	}
-  	/* HH_IGNORE_ERROR[4110] */
-  	if (self::$teams_by_completed_level->contains($level_id)) return self::$teams_by_completed_level->get($level_id);
-  	else return array();
+    $teams_by_completed_level = self::getMCRecords('TEAMS_BY_LEVEL');
+    /* HH_IGNORE_ERROR[4062] */
+    if ($teams_by_completed_level->contains($level_id)) {
+      /* HH_IGNORE_ERROR[4062] */
+      return $teams_by_completed_level->get($level_id);
+    } else {
+      return array();
+    }
   }
-  
+
   public static async function genFirstCapture(
     int $level_id,
     bool $refresh = false,
   ): Awaitable<Team> {
-    if ((count(self::$first_team_captured_by_level) === 0) || ($refresh)) {
+    $mc_result = self::getMCRecords('TEAMS_FIRST_CAP');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
     	$first_team_captured_by_level = array();
       $teams = await self::genTeamArrayFromDB('SELECT * FROM teams LEFT JOIN scores_log ON teams.id = scores_log.team_id WHERE scores_log.ts IN (SELECT MIN(scores_log.ts) FROM scores_log GROUP BY scores_log.level_id)');
       foreach ($teams->items() as $team) {
       	$first_team_captured_by_level[intval($team->get("level_id"))] = Team::teamFromRow($team);
       }
-      self::setFirstTeamCapturedByLevel(new Map($first_team_captured_by_level));
+      self::setMCRecords('TEAMS_FIRST_CAP', new Map($first_team_captured_by_level));
     }
-    /* HH_IGNORE_ERROR[4110] */
-    return self::$first_team_captured_by_level->get($level_id);
+    $first_team_captured_by_level = self::getMCRecords('TEAMS_FIRST_CAP');
+    /* HH_IGNORE_ERROR[4062] */
+    return $first_team_captured_by_level->get($level_id);
   }
 }

--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -8,6 +8,7 @@ class Session extends Model {
     private int $team_id,
     private string $created_ts,
     private string $last_access_ts,
+    private string $last_page_access,
   ) {}
 
   public function getId(): int {
@@ -34,6 +35,10 @@ class Session extends Model {
     return $this->last_access_ts;
   }
 
+  public function getLastPageAccess(): string {
+    return $this->last_page_access;
+  }
+
   private static function decodeTeamId(string $data): int {
     // This is a bit janky
     $delim = explode('team_id|', $data)[1];
@@ -47,6 +52,7 @@ class Session extends Model {
     string $cookie,
     string $data,
   ): Awaitable<void> {
+    if (Router::isRequestAjax() || !Router::isRequestRouter()) return;
     $team_id = self::decodeTeamId($data);
     $db = await self::genDb();
     await $db->queryf(
@@ -64,6 +70,7 @@ class Session extends Model {
       intval(must_have_idx($row, 'team_id')),
       must_have_idx($row, 'created_ts'),
       must_have_idx($row, 'last_access_ts'),
+      must_have_idx($row, 'last_page_access'),
     );
   }
 
@@ -74,9 +81,10 @@ class Session extends Model {
   ): Awaitable<void> {
     $db = await self::genDb();
     await $db->queryf(
-      'INSERT INTO sessions (cookie, data, created_ts, last_access_ts, team_id) VALUES (%s, %s, NOW(), NOW(), 1)',
+      'INSERT INTO sessions (cookie, data, created_ts, last_access_ts, team_id, last_page_access) VALUES (%s, %s, NOW(), NOW(), 1, %s)',
       $cookie,
       $data,
+      Router::getRequestedPage(),
     );
   }
 
@@ -107,15 +115,30 @@ class Session extends Model {
     return intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0;
   }
 
+  public static async function genSessionDataIfExist(string $cookie): Awaitable<string> {
+    $db = await self::genDb();
+    $result = await $db->queryf(
+      'SELECT * FROM sessions WHERE cookie = %s LIMIT 1',
+      $cookie,
+    );
+
+    if ($result->numRows() === 1) {
+      $session = self::sessionFromRow($result->mapRows()[0]);
+      return $session->getData();
+    } else return '';
+  }
+
   // Update the session for a given cookie.
   public static async function genUpdate(
     string $cookie,
     string $data,
   ): Awaitable<void> {
+    if (Router::isRequestAjax() || !Router::isRequestRouter()) return;
     $db = await self::genDb();
     await $db->queryf(
-      'UPDATE sessions SET last_access_ts = NOW(), data = %s WHERE cookie = %s LIMIT 1',
+      'UPDATE sessions SET last_access_ts = NOW(), data = %s, last_page_access = %s WHERE cookie = %s LIMIT 1',
       $data,
+      Router::getRequestedPage(),
       $cookie,
     );
   }
@@ -140,6 +163,7 @@ class Session extends Model {
 
   // Does cleanup of cookies.
   public static async function genCleanup(int $maxlifetime): Awaitable<void> {
+    if (Router::isRequestAjax() || !Router::isRequestRouter()) return;
     $db = await self::genDb();
     // Clean up expired sessions
     await $db->queryf(

--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -52,7 +52,9 @@ class Session extends Model {
     string $cookie,
     string $data,
   ): Awaitable<void> {
-    if (Router::isRequestAjax() || !Router::isRequestRouter()) return;
+    if (Router::isRequestAjax() || !Router::isRequestRouter()) {
+      return;
+    }
     $team_id = self::decodeTeamId($data);
     $db = await self::genDb();
     await $db->queryf(
@@ -125,7 +127,9 @@ class Session extends Model {
     if ($result->numRows() === 1) {
       $session = self::sessionFromRow($result->mapRows()[0]);
       return $session->getData();
-    } else return '';
+    } else {
+      return '';
+    }
   }
 
   // Update the session for a given cookie.
@@ -133,7 +137,9 @@ class Session extends Model {
     string $cookie,
     string $data,
   ): Awaitable<void> {
-    if (Router::isRequestAjax() || !Router::isRequestRouter()) return;
+    if (Router::isRequestAjax() || !Router::isRequestRouter()) {
+      return;
+    }
     $db = await self::genDb();
     await $db->queryf(
       'UPDATE sessions SET last_access_ts = NOW(), data = %s, last_page_access = %s WHERE cookie = %s LIMIT 1',
@@ -163,7 +169,9 @@ class Session extends Model {
 
   // Does cleanup of cookies.
   public static async function genCleanup(int $maxlifetime): Awaitable<void> {
-    if (Router::isRequestAjax() || !Router::isRequestRouter()) return;
+    if (Router::isRequestAjax() || !Router::isRequestRouter()) {
+      return;
+    }
     $db = await self::genDb();
     // Clean up expired sessions
     await $db->queryf(

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -59,7 +59,7 @@ class Team extends Model implements Importable, Exportable {
     return $this->created_ts;
   }
 
-  private static function teamFromRow(Map<string, string> $row): Team {
+  protected static function teamFromRow(Map<string, string> $row): Team {
     return new Team(
       intval(must_have_idx($row, 'id')),
       intval(must_have_idx($row, 'active')),
@@ -589,7 +589,7 @@ class Team extends Model implements Importable, Exportable {
   // Get rank position for a team
   public static async function genMyRank(int $team_id): Awaitable<int> {
     $rank = 1;
-    $leaderboard = await self::genLeaderboard();
+    $leaderboard = await MultiTeam::genLeaderboard();
     foreach ($leaderboard as $team) {
       if ($team_id === $team->getId()) {
         return $rank;

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -323,6 +323,7 @@ class Team extends Model implements Importable, Exportable {
       $password_hash,
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Delete team.
@@ -332,6 +333,7 @@ class Team extends Model implements Importable, Exportable {
       'DELETE FROM teams WHERE id = %d AND protected = 0 LIMIT 1',
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Enable or disable teams by passing 1 or 0.
@@ -345,6 +347,7 @@ class Team extends Model implements Importable, Exportable {
       $status ? 1 : 0,
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Enable or disable all teams by passing 1 or 0.
@@ -354,6 +357,7 @@ class Team extends Model implements Importable, Exportable {
       'UPDATE teams SET active = %d WHERE id > 0 AND protected = 0',
       $status ? 1 : 0,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Sets toggles team admin status.
@@ -367,6 +371,7 @@ class Team extends Model implements Importable, Exportable {
       $admin ? 1 : 0,
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Enable or disable team visibility by passing 1 or 0.
@@ -380,6 +385,7 @@ class Team extends Model implements Importable, Exportable {
       $visible ? 1 : 0,
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Check if a team name is already created.

--- a/src/static/svg/map/world.php
+++ b/src/static/svg/map/world.php
@@ -71,7 +71,7 @@ class WorldMapController {
           } else if ($other_previous_score) {
             $map_indicator .= 'captured--opponent';
             $completed_by =
-              await Team::genCompletedLevel($level->getId());
+              await MultiTeam::genCompletedLevel($level->getId());
             $data_captured = '';
             foreach ($completed_by as $c) {
               $data_captured .= ' '.$c->getName();

--- a/tests/models/MultiTeamTest.php
+++ b/tests/models/MultiTeamTest.php
@@ -1,0 +1,136 @@
+<?hh
+
+class MultiTeamTest extends FBCTFTest {
+
+  public function testAll(): void {
+    $all = HH\Asio\join(MultiTeam::genAllTeams());
+    $this->assertEquals(1, count($all));
+
+    //test parent class methods
+    $t = $all[0];
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+
+    //test single team using multiteam cache
+    $t = HH\Asio\join(MultiTeam::genTeam(1));
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+
+    //test single team using multiteam leaderboard cache
+    $all = HH\Asio\join(MultiTeam::genLeaderboard());
+    $this->assertEquals(1, count($all));
+    $t = $all[0];
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+
+    //test points from multiteam cache
+    $t = HH\Asio\join(MultiTeam::genPointsByType(1, 'flag'));
+    $this->assertEquals(10, $t);
+
+    //test single team using multiteam active team cache
+    $all = HH\Asio\join(MultiTeam::genAllActiveTeams());
+    $this->assertEquals(1, count($all));
+    $t = $all[0];
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+
+    //test single team using multiteam visible team cache
+    $all = HH\Asio\join(MultiTeam::genAllVisibleTeams());
+    $this->assertEquals(1, count($all));
+    $t = $all[0];
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+
+    //test single team using multiteam logo team cache
+    $all = HH\Asio\join(MultiTeam::genWhoUses('logo'));
+    $this->assertEquals(1, count($all));
+    $t = $all[0];
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+
+    //test single team using multiteam level completed cache
+    $all = HH\Asio\join(MultiTeam::genCompletedLevel(2));
+    $this->assertEquals(1, count($all));
+    $t = $all[0];
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+
+    //test single team using multiteam first capture cache
+    $t = HH\Asio\join(MultiTeam::genFirstCapture(2));
+    $this->assertEquals(1, $t->getId());
+    $this->assertTrue($t->getActive());
+    $this->assertFalse($t->getAdmin());
+    $this->assertFalse($t->getProtected());
+    $this->assertTrue($t->getVisible());
+    $this->assertEquals('name', $t->getName());
+    $this->assertEquals('password_hash', $t->getPasswordHash());
+    $this->assertEquals(10, $t->getPoints());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getLastScore());
+    $this->assertEquals('logo', $t->getLogo());
+    $this->assertEquals('2015-04-26 12:14:20', $t->getCreatedTs());
+  }
+}
+  


### PR DESCRIPTION
* Creation of the MultiTeam class, extending the Team class and overloading certain class methods to combine database queries and retain data retrieved from the database for subsequent usage.  Overall, this class dramatically reduces the queries to the teams table.  Specifically, this ensures queries are only called once per page request.

* MultiTeam::genTeam() replaces the Team instantiation with a method that utilizes the teams database results stored within the Multi::Team class.  All Team::genTeam() calls have been updated to utilize MultiTeam::genTeam().  This reduces the number of queries when building multiple team objects from 1(n) to 1.

* MultiTeam::genLeaderboard() replaces the method to retrieve a sorted array of Team objects used for scoring displays.  Previously this would query the database 1(n) times per team. It is now performing one query per page request that includes any leaderboard display.

* MultiTeam::genPointsByType() replaces the retrieval of scores by various type (flag, quiz, base).  This is primarily used by the Scoreboard display.  Previously, when building the scoring display, the database would be queried 3(n) times per team. The new method only queries the database once per page request.

* MultiTeam::genAllActiveTeams() replaces the method used to find all active teams.  While this was only performing a single query previously, the data was not retained.  In the past, if there were multiple calls to Team::genAllActiveTeams() within the same code execution (request) it would perform multiple queries.  The new overloaded method now reduces this query against the database to once per page request.

* MultiTeam::genAllVisibleTeams() replaces the method used to find all visible teams.  While this was only performing a single query previously, the data was not retained.  In the past, if there were multiple calls to Team:: genAllVisibleTeams() within the same code execution (request) it would perform multiple queries.  The new overloaded method now reduces this query against the database to once per page request.

* MultiTeam::genWhoUses replaces the team-by-logo retrieval.  This method will return the teams who use a particular logo, which is used on both the Scoreboard and the administrative team page.  In the past, this would perform one query per logo.  The queries have been reduced from hundreds to one, per page request.

* MultiTeam::genCompletedLevel() replaces the method used to find particular levels that have been completed, and who completed the levels.  Previously this would query the database 1(n) times, per level, and is now performing 1 query per page request that includes any leaderboard display

* MultiTeam::genFirstCapture() replaces the method used to determine who captured a particular scoring level first.  Previously this was called for all levels 1(n) times and is now called once per page request.

* Updated relevant calls to the aforementioned Team class methods which have now been overloaded by the MultiTeam class.  The team class has been left intact as the possibility exists that there will be valid use cases where specific, singular team, queries are valid.  It is also possible that specific, singular team functionality or extension of the functionality may be needed in the future, along with backward compatibility. Alternatively, the MultiTeam class could be merged into Team in the future.

* Added Router::getRequestedPage(), Router::isRequestAjax(), and Router::isRequestRouter() to the Router class.

* Router::getRequestedPage() will return either the "page" $_REQUEST variable, if set, or the "p" $_REQUEST variable.  This can be used to determine which page was requested.  This provides filter functionality based off of the requested page or utilization of the value for logging.

* Router::isRequestAjax() will return a boolean.  This method can be used whenever specific functionality needs to be filtered based on whether the request was an XHR or not.  Note, that currently, not all XHR go through the Router class.

* Router::isRequestRouter() will return a boolean.  This method can be used whenever specific functionality needs to be filtered based on whether or not the request went through the Router or not.

* SessionUtils::read() has been updated to utilize a single method to return the session data.  Previously there was first a request to the session table within the database to determine if the session existed, then a second query would retrieve the session data.  Now the checking of the session and return of the session data take place within a single database query.  The new method is Session:genSessionDataIfExists().

* Session::getLastPageAccess() has been added to the Session class.  This method will return the last page that was requested. The last page requested is retrieved from Router::getRequestedPage() and is therefore based on the "p" or "page" value from $_REQUEST.

* The sessions table within the database has been updated to include a "last_page_access" column, which now contains the last page that was accessed when the session was last updated.

* Both Session::genCreate() and Session::genUpdate() have been updated to include the new database column on insert or update.

* Session::genUpdate() and Session::getCleanup() are no longer executing on every request.  These functions now filter out any request which is an AJAX request or doesn't go through the Router class.  Currently, modals are still being tracked, but this can be changed if further query reduction is desired.  Overall, this results in a massive reduction in queries to the session table, which was happening on a continual basis due to the scoreboard updates via XHR.  This should resolve facebook/fbctf#185.

* The admin Sessions page has been updated to display the last page access.  This was added to make up for the loss of fidelity on the last access time, as XHR will no longer update the session and therefore no longer update the last access time.  However, using a combination of the last access time and the last access page, it can be determined what a user is doing, including if they are idling on the Scoreboard display.  This seems to be a favorable compromise, especially given the massive query reduction it provides.

* Updated relevant language files for the new Last Page Access display.