### PR TITLE
LDAP Support For Registration and Login

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -198,6 +198,10 @@ INSERT INTO `configuration` (field, value, description) VALUES("registration", "
 INSERT INTO `configuration` (field, value, description) VALUES("registration_names", "0", "(Boolean) Registration will ask for names");
 INSERT INTO `configuration` (field, value, description) VALUES("registration_type", "1", "(Integer) Type of registration: 1 - Open; 2 - Tokenized;");
 INSERT INTO `configuration` (field, value, description) VALUES("registration_players", "3", "(Integer) Number of players per team");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap", "0", "(Boolean) Ability to use LDAP to login");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap_server", "ldap://localhost", "(String) LDAP Server");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap_port", "389", "(Integer) LDAP Port");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap_domain_suffix", "@localhost", "(String) LDAP Domain");
 INSERT INTO `configuration` (field, value, description) VALUES("login", "1", "(Boolean) Ability to login");
 INSERT INTO `configuration` (field, value, description) VALUES("login_select", "0", "(Boolean) Login selecting the team");
 INSERT INTO `configuration` (field, value, description) VALUES("login_strongpasswords", "0", "(Boolean) Enforce using strong passwords");

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -198,6 +198,10 @@ INSERT INTO `configuration` (field, value, description) VALUES("registration", "
 INSERT INTO `configuration` (field, value, description) VALUES("registration_names", "0", "(Boolean) Registration will ask for names");
 INSERT INTO `configuration` (field, value, description) VALUES("registration_type", "1", "(Integer) Type of registration: 1 - Open; 2 - Tokenized;");
 INSERT INTO `configuration` (field, value, description) VALUES("registration_players", "3", "(Integer) Number of players per team");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap", "0", "(Boolean) Ability to use LDAP to login");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap_server", "ldap://localhost", "(String) LDAP Server");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap_port", "389", "(Integer) LDAP Port");
+INSERT INTO `configuration` (field, value, description) VALUES("ldap_domain_suffix", "@localhost", "(String) LDAP Domain");
 INSERT INTO `configuration` (field, value, description) VALUES("login", "1", "(Boolean) Ability to login");
 INSERT INTO `configuration` (field, value, description) VALUES("login_select", "0", "(Boolean) Login selecting the team");
 INSERT INTO `configuration` (field, value, description) VALUES("login_strongpasswords", "0", "(Boolean) Enforce using strong passwords");

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -278,6 +278,10 @@ class AdminController extends Controller {
       'login_select' => Configuration::gen('login_select'),
       'login_strongpasswords' => Configuration::gen('login_strongpasswords'),
       'registration_names' => Configuration::gen('registration_names'),
+      'ldap' => Configuration::gen('ldap'),
+      'ldap_server' => Configuration::gen('ldap_server'),
+      'ldap_port' => Configuration::gen('ldap_port'),
+      'ldap_domain_suffix' => Configuration::gen('ldap_domain_suffix'),
       'scoring' => Configuration::gen('scoring'),
       'gameboard' => Configuration::gen('gameboard'),
       'timer' => Configuration::gen('timer'),
@@ -297,6 +301,10 @@ class AdminController extends Controller {
     $login_select = $results['login_select'];
     $login_strongpasswords = $results['login_strongpasswords'];
     $registration_names = $results['registration_names'];
+    $ldap = $results['ldap'];
+    $ldap_server = $results['ldap_server'];
+    $ldap_port = $results['ldap_port'];
+    $ldap_domain_suffix = $results['ldap_domain_suffix'];
     $scoring = $results['scoring'];
     $gameboard = $results['gameboard'];
     $timer = $results['timer'];
@@ -313,6 +321,8 @@ class AdminController extends Controller {
     $login_off = $login->getValue() === '0';
     $login_select_on = $login_select->getValue() === '1';
     $login_select_off = $login_select->getValue() === '0';
+    $ldap_on = $ldap->getValue() === '1';
+    $ldap_off = $ldap->getValue() === '0';
     $strong_passwords_on = $login_strongpasswords->getValue() === '1';
     $strong_passwords_off = $login_strongpasswords->getValue() === '0';
     $registration_names_on = $registration_names->getValue() === '1';
@@ -528,6 +538,61 @@ class AdminController extends Controller {
                           {tr('Off')}
                         </label>
                       </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section class="admin-box">
+                <header class="admin-box-header">
+                  <h3>{tr('Active Directory / LDAP')}</h3>
+                  <div class="admin-section-toggle radio-inline">
+                    <input
+                      type="radio"
+                      name="fb--conf--ldap"
+                      id="fb--conf--ldap--on"
+                      checked={$ldap_on}
+                    />
+                    <label for="fb--conf--ldap--on">{tr('On')}</label>
+                    <input
+                      type="radio"
+                      name="fb--conf--ldap"
+                      id="fb--conf--ldap--off"
+                      checked={$ldap_off}
+                    />
+                    <label for="fb--conf--ldap--off">{tr('Off')}</label>
+                  </div>
+                </header>
+                <div class="fb-column-container">
+                  <div class="col col-pad col-1-4">
+                    <div class="form-el el--block-label el--full-text">
+                      <label>{tr('LDAP Server')}</label>
+                      <input
+                        type="text"
+                        value={$ldap_server->getValue()}
+                        name="fb--conf--ldap_server"
+                      />
+                    </div>
+                  </div>
+                  <div class="col col-pad col-2-4">
+                    <div class="form-el el--block-label">
+                      <label>{tr('LDAP Port')}</label>
+                      <input
+                        type="number"
+                        min="1"
+                        max="65535"
+                        value={$ldap_port->getValue()}
+                        name="fb--conf--ldap_port"
+                      />
+                    </div>
+                  </div>
+                  <div class="col col-pad col-3-4">
+                    <div class="form-el el--block-label el--full-text">
+                      <label>{tr('LDAP Domain')}</label>
+                      <input
+                        type="text"
+                        value={$ldap_domain_suffix->getValue()}
+                        name="fb--conf--ldap_domain_suffix"
+                      />
                     </div>
                   </div>
                 </div>

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -285,6 +285,13 @@ class IndexController extends Controller {
       $token_field = <div></div>;
     }
 
+    $ldap = await Configuration::gen('ldap');
+    $ldap_domain_suffix = "";
+    if ($ldap->getValue() === '1') {
+      $ldap_domain_suffix = await Configuration::gen('ldap_domain_suffix');
+      $ldap_domain_suffix = $ldap_domain_suffix->getValue();
+    }
+
     $logos_section = await $this->genRenderLogosSelection();
     return
       <main
@@ -315,7 +322,7 @@ class IndexController extends Controller {
                   name="teamname"
                   type="text"
                   maxlength={20}
-                />
+                /> {$ldap_domain_suffix}
               </div>
               <div class="form-el el--text">
                 <label for="">{tr('Password')}</label>
@@ -354,6 +361,13 @@ class IndexController extends Controller {
       $token_field = <div></div>;
     }
 
+    $ldap = await Configuration::gen('ldap');
+    $ldap_domain_suffix = "";
+    if ($ldap->getValue() === '1') {
+      $ldap_domain_suffix = await Configuration::gen('ldap_domain_suffix');
+      $ldap_domain_suffix = $ldap_domain_suffix->getValue();
+    }
+
     $logos_section = await $this->genRenderLogosSelection();
     return
       <main
@@ -380,7 +394,7 @@ class IndexController extends Controller {
                   name="teamname"
                   type="text"
                   maxlength={20}
-                />
+                /> {$ldap_domain_suffix}
               </div>
               <div class="form-el el--text">
                 <label for="">{tr('Password')}</label>
@@ -448,6 +462,12 @@ class IndexController extends Controller {
 
   public async function genRenderLoginContent(): Awaitable<:xhp> {
     $login = await Configuration::gen('login');
+    $ldap = await Configuration::gen('ldap');
+    $ldap_domain_suffix = "";
+    if ($ldap->getValue() === '1') {
+      $ldap_domain_suffix = await Configuration::gen('ldap_domain_suffix');
+      $ldap_domain_suffix = $ldap_domain_suffix->getValue();
+    }
     if ($login->getValue() === '1') {
       $login_team =
         <input
@@ -496,7 +516,7 @@ class IndexController extends Controller {
               <fieldset class="form-set fb-container container--small">
                 <div class="form-el el--text">
                   <label for="">{tr('Team Name')}</label>
-                  {$login_team}
+                  {$login_team} {$ldap_domain_suffix}
                 </div>
                 <div class="form-el el--text">
                   <label for="">{tr('Password')}</label>

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -322,7 +322,8 @@ class IndexController extends Controller {
                   name="teamname"
                   type="text"
                   maxlength={20}
-                /> {$ldap_domain_suffix}
+                />
+                {$ldap_domain_suffix}
               </div>
               <div class="form-el el--text">
                 <label for="">{tr('Password')}</label>
@@ -394,7 +395,8 @@ class IndexController extends Controller {
                   name="teamname"
                   type="text"
                   maxlength={20}
-                /> {$ldap_domain_suffix}
+                />
+                {$ldap_domain_suffix}
               </div>
               <div class="form-el el--text">
                 <label for="">{tr('Password')}</label>

--- a/src/controllers/ajax/IndexAjaxController.php
+++ b/src/controllers/ajax/IndexAjaxController.php
@@ -115,21 +115,32 @@ class IndexAjaxController extends AjaxController {
       $ldap_port = await Configuration::gen('ldap_port');
       $ldap_domain_suffix = await Configuration::gen('ldap_domain_suffix');
       // connect to ldap server
-      $ldapconn = ldap_connect($ldap_server->getValue(), intval($ldap_port->getValue()));
+      $ldapconn = ldap_connect(
+        $ldap_server->getValue(),
+        intval($ldap_port->getValue()),
+      );
       if (!$ldapconn)
-        return Utils::error_response('Could not connect to LDAP server', 'registration');
+        return Utils::error_response(
+          'Could not connect to LDAP server',
+          'registration',
+        );
       $teamname = trim($teamname);
-      $bind = ldap_bind($ldapconn, $teamname.$ldap_domain_suffix->getValue(), $password);
+      $bind = ldap_bind(
+        $ldapconn,
+        $teamname.$ldap_domain_suffix->getValue(),
+        $password,
+      );
       if (!$bind)
-        return Utils::error_response('LDAP Credentials Error', 'registration');
+        return
+          Utils::error_response('LDAP Credentials Error', 'registration');
       // Use randomly generated password for local account for LDAP users
       // This will help avoid leaking users ldap passwords if the server's database
       // is compromised.
       $ldap_password = $password;
       $password = gmp_strval(
-            gmp_init(bin2hex(openssl_random_pseudo_bytes(16)), 16),
-            62,
-          );
+        gmp_init(bin2hex(openssl_random_pseudo_bytes(16)), 16),
+        62,
+      );
     }
 
     // Check if tokenized registration is enabled
@@ -177,8 +188,7 @@ class IndexAjaxController extends AjaxController {
         }
         // Login the team
         if ($ldap->getValue() === '1')
-          return await $this->genLoginTeam($team_id, $ldap_password);
-        else
+          return await $this->genLoginTeam($team_id, $ldap_password); else
           return await $this->genLoginTeam($team_id, $password);
       } else {
         return Utils::error_response('Registration failed', 'registration');

--- a/src/controllers/ajax/IndexAjaxController.php
+++ b/src/controllers/ajax/IndexAjaxController.php
@@ -107,6 +107,31 @@ class IndexAjaxController extends AjaxController {
       return Utils::error_response('Registration failed', 'registration');
     }
 
+    // Check if ldap is enabled and verify credentials if successful
+    $ldap = await Configuration::gen('ldap');
+    if ($ldap->getValue() === '1') {
+      // Get server information from configuration
+      $ldap_server = await Configuration::gen('ldap_server');
+      $ldap_port = await Configuration::gen('ldap_port');
+      $ldap_domain_suffix = await Configuration::gen('ldap_domain_suffix');
+      // connect to ldap server
+      $ldapconn = ldap_connect($ldap_server->getValue(), intval($ldap_port->getValue()));
+      if (!$ldapconn)
+        return Utils::error_response('Could not connect to LDAP server', 'registration');
+      $teamname = trim($teamname);
+      $bind = ldap_bind($ldapconn, $teamname.$ldap_domain_suffix->getValue(), $password);
+      if (!$bind)
+        return Utils::error_response('LDAP Credentials Error', 'registration');
+      // Use randomly generated password for local account for LDAP users
+      // This will help avoid leaking users ldap passwords if the server's database
+      // is compromised.
+      $ldap_password = $password;
+      $password = gmp_strval(
+            gmp_init(bin2hex(openssl_random_pseudo_bytes(16)), 16),
+            62,
+          );
+    }
+
     // Check if tokenized registration is enabled
     $registration_type = await Configuration::gen('registration_type');
     if ($registration_type->getValue() === '2') {
@@ -151,7 +176,10 @@ class IndexAjaxController extends AjaxController {
           await Token::genUse($token, $team_id);
         }
         // Login the team
-        return await $this->genLoginTeam($team_id, $password);
+        if ($ldap->getValue() === '1')
+          return await $this->genLoginTeam($team_id, $ldap_password);
+        else
+          return await $this->genLoginTeam($team_id, $password);
       } else {
         return Utils::error_response('Registration failed', 'registration');
       }

--- a/src/language/lang_basque.php
+++ b/src/language/lang_basque.php
@@ -642,4 +642,12 @@ $translations = array(
     'Skip to play',
   'Powered By Facebook' =>
     'Nork Facebook By',
+  'Active Directory / LDAP' =>
+    'Active Directory / LDAP',
+  'LDAP Server' =>
+    'LDAP Server',
+  'LDAP Port' =>
+    'LDAP Port',
+  'LDAP Domain' =>
+    'LDAP Domain',
 );

--- a/src/language/lang_cat.php
+++ b/src/language/lang_cat.php
@@ -658,4 +658,12 @@ $translations = array(
     'Salta per començar a jugar',
   'Powered By Facebook' =>
     'Powered By Facebook',
+  'Active Directory / LDAP' =>
+    'Active Directory / LDAP',
+  'LDAP Server' =>
+    'LDAP Server',
+  'LDAP Port' =>
+    'LDAP Port',
+  'LDAP Domain' =>
+    'LDAP Domain',
 );

--- a/src/language/lang_en.php
+++ b/src/language/lang_en.php
@@ -658,4 +658,12 @@ $translations = array(
     'Skip to play',
   'Powered By Facebook' =>
     'Powered By Facebook',
+  'Active Directory / LDAP' =>
+    'Active Directory / LDAP',
+  'LDAP Server' =>
+    'LDAP Server',
+  'LDAP Port' =>
+    'LDAP Port',
+  'LDAP Domain' =>
+    'LDAP Domain',
 );

--- a/src/language/lang_es.php
+++ b/src/language/lang_es.php
@@ -642,4 +642,12 @@ $translations = array(
     'Continuar para jugar',
   'Powered By Facebook' =>
     'Powered By Facebook',
+  'Active Directory / LDAP' =>
+    'Active Directory / LDAP',
+  'LDAP Server' =>
+    'LDAP Server',
+  'LDAP Port' =>
+    'LDAP Port',
+  'LDAP Domain' =>
+    'LDAP Domain',
 );

--- a/src/language/lang_hu.php
+++ b/src/language/lang_hu.php
@@ -642,4 +642,12 @@ $translations = array(
     'Vissza a játékhoz',
   'Powered By Facebook' =>
     'Powered By Facebook',
+  'Active Directory / LDAP' =>
+    'Active Directory / LDAP',
+  'LDAP Server' =>
+    'LDAP Server',
+  'LDAP Port' =>
+    'LDAP Port',
+  'LDAP Domain' =>
+    'LDAP Domain',
 );

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -176,11 +176,18 @@ class Team extends Model implements Importable, Exportable {
         $ldap_server = await Configuration::gen('ldap_server');
         $ldap_port = await Configuration::gen('ldap_port');
         $ldap_domain_suffix = await Configuration::gen('ldap_domain_suffix');
-        $ldapconn = ldap_connect($ldap_server->getValue(), intval($ldap_port->getValue()));
+        $ldapconn = ldap_connect(
+          $ldap_server->getValue(),
+          intval($ldap_port->getValue()),
+        );
         if (!$ldapconn)
           return null;
         $team_name = trim($team->getName());
-        $bind = ldap_bind($ldapconn, $team_name.$ldap_domain_suffix->getValue(), $password);
+        $bind = ldap_bind(
+          $ldapconn,
+          $team_name.$ldap_domain_suffix->getValue(),
+          $password,
+        );
         if (!$bind)
           return null;
         //Successful Login via LDAP

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -168,6 +168,25 @@ class Team extends Model implements Importable, Exportable {
       invariant($result->numRows() === 1, 'Expected exactly one result');
       $team = self::teamFromRow($result->mapRows()[0]);
 
+      // Check if ldap is enabled and verify credentials if successful
+      // An exception is admin user, which is verified locally
+      $ldap = await Configuration::gen('ldap');
+      if ($ldap->getValue() === '1' && !$team->getAdmin()) {
+        // Get server information from configuration
+        $ldap_server = await Configuration::gen('ldap_server');
+        $ldap_port = await Configuration::gen('ldap_port');
+        $ldap_domain_suffix = await Configuration::gen('ldap_domain_suffix');
+        $ldapconn = ldap_connect($ldap_server->getValue(), intval($ldap_port->getValue()));
+        if (!$ldapconn)
+          return null;
+        $team_name = trim($team->getName());
+        $bind = ldap_bind($ldapconn, $team_name.$ldap_domain_suffix->getValue(), $password);
+        if (!$bind)
+          return null;
+        //Successful Login via LDAP
+        return $team;
+      }
+
       if (password_verify($password, $team->getPasswordHash())) {
         if (self::regenerateHash($team->getPasswordHash())) {
           $new_hash = self::generateHash($password);

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -1100,11 +1100,11 @@ module.exports = {
     });
 
     // configuration fields
-    $('select,input[type="number"][name^="fb--conf"]').on('change', function() {
+    $('select,input[type="number"][name^="fb--conf"],input[type="text"][name^="fb--conf"]').on('change', function() {
       var $this = $(this);
       var field = $this.attr('name').split('--')[2];
       var value = '';
-      if ($this.attr('type') === 'number') {
+      if ($this.attr('type') === 'number' || $this.attr('type') === 'text') {
         value = $(this)[0].value;
       } else {
         value = $('option:selected', $this)[0].value;


### PR DESCRIPTION
This change enables LDAP support for registration and login (Issue #126). The basic workflow is as follows.
1. The admin user enables LDAP and configures the following options.
   - LDAP Server
   - LDAP Port
   - LDAP Domain Suffix for Logging in (such as '@domain.com')
2. The player registers by using LDAP username as the team name, and using LDAP credentials. On successful validation of credentials, the team is created locally with a random local password to avoid compromise of LDAP password if the server's database is compromised at a later stage.
3. The player logs in and plays the game using LDAP username as the team name and using LDAP credentials. Password is verified against LDAP server instead of local database.

The registration and login workflows remain the same as before, if LDAP is disabled.

Additional Changes:
1. This change also adds support for text based configuration properties. (Previously only number inputs were being updated in the database using ajax calls)
2. Placeholders for the LDAP related text strings have been added to existing language files. Contributions towards providing good translations are welcome.

Testing:
This fork has been tested in a corporate LDAP environment and is working well without hitches.
