### PR TITLE
Forbid correct answer submissions on inactive levels

### DIFF
--- a/src/controllers/ajax/GameAjaxController.php
+++ b/src/controllers/ajax/GameAjaxController.php
@@ -43,20 +43,22 @@ class GameAjaxController extends AjaxController {
       case 'answer_level':
         $scoring = await Configuration::gen('scoring');
         if ($scoring->getValue() === '1') {
-          $check_base =
-            await Level::genCheckBase(must_have_int($params, 'level_id'));
+          $level_id = must_have_int($params, 'level_id');
+          $answer = must_have_string($params, 'answer');
+          $check_base = await Level::genCheckBase($level_id);
+          $check_status = await Level::genCheckStatus($level_id);
           $check_answer = await Level::genCheckAnswer(
-            must_have_int($params, 'level_id'),
-            must_have_string($params, 'answer'),
+            $level_id,
+            $answer,
           );
-          // Check if level is not a base
-          if ($check_base) {
+          // Check if level is not a base or if level isn't active
+          if ($check_base || !$check_status) {
             return Utils::error_response('Failed', 'game');
             // Check if answer is valid
           } else if ($check_answer) {
             // Give points!
             await Level::genScoreLevel(
-              must_have_int($params, 'level_id'),
+              $level_id,
               SessionUtils::sessionTeam(),
             );
             // Update teams last score
@@ -64,9 +66,9 @@ class GameAjaxController extends AjaxController {
             return Utils::ok_response('Success', 'game');
           } else {
             await FailureLog::genLogFailedScore(
-              must_have_int($params, 'level_id'),
+              $level_id,
               SessionUtils::sessionTeam(),
-              must_have_string($params, 'answer'),
+              $answer,
             );
             return Utils::error_response('Failed', 'game');
           }


### PR DESCRIPTION
This part of the code still allows correct answer submissions on inactive levels, which can lead to weird UI states. This commit prevents that behavior. I also made `$level_id` and `$answer` into variables to improve readability of this part.