### PR TITLE
Fix index error in genFirstCapture in Teams.php

### DIFF
--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -561,7 +561,7 @@ class Team extends Model implements Importable, Exportable {
     $db = await self::genDb();
     $result =
       await $db->queryf(
-        'SELECT * FROM teams WHERE id = (SELECT team_id FROM scores_log WHERE level_id = %d ORDER BY ts LIMIT 0,1) AND visible = 1 AND active = 1',
+        'SELECT * FROM teams WHERE id = (SELECT team_id FROM scores_log WHERE level_id = %d AND team_id IN (SELECT id FROM teams WHERE visible = 1 AND active = 1) ORDER BY ts LIMIT 0,1)',
         $level_id,
       );
     return self::teamFromRow($result->mapRows()[0]);


### PR DESCRIPTION
genFirstCapture would throw an error due to the query return no rows, but the return statement requires one row (due to the [0] ). This would happen when a disabled or invisible user was had the first (but not only) capture. I used a second sub-query to fix this as the rest of this code base appears to favor sub-queries instead of joins.
