### PR TITLE
Fix for import/export levels, since country names are not present

### DIFF
--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -210,13 +210,13 @@ class Country extends Model {
     return $new_country;
   }
 
-  // Get a country by name.
+  // Get a country by iso_code.
   public static async function genCountry(
     string $country,
   ): Awaitable<Country> {
     $db = await self::genDb();
     $result = await $db->queryf(
-      'SELECT * FROM countries WHERE name = %s LIMIT 1',
+      'SELECT * FROM countries WHERE iso_code = %s LIMIT 1',
       $country,
     );
 
@@ -257,14 +257,14 @@ class Country extends Model {
     );
   }
 
-  // Check if a country already exists, by name.
+  // Check if a country already exists, by iso_code
   public static async function genCheckExists(
     string $country,
   ): Awaitable<bool> {
     $db = await self::genDb();
 
     $result = await $db->queryf(
-      'SELECT COUNT(*) FROM countries WHERE name = %s',
+      'SELECT COUNT(*) FROM countries WHERE iso_code = %s',
       $country,
     );
 

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -123,13 +123,13 @@ class Level extends Model implements Importable, Exportable {
     foreach ($elements as $level) {
       $title = must_have_string($level, 'title');
       $type = must_have_string($level, 'type');
-      $entity_name = must_have_string($level, 'entity_name');
+      $entity_iso_code = must_have_string($level, 'entity_iso_code');
       $c = must_have_string($level, 'category');
-      $exist = await self::genAlreadyExist($type, $title, $entity_name);
-      $entity_exist = await Country::genCheckExists($entity_name);
+      $exist = await self::genAlreadyExist($type, $title, $entity_iso_code);
+      $entity_exist = await Country::genCheckExists($entity_iso_code);
       $category_exist = await Category::genCheckExists($c);
       if (!$exist && $entity_exist && $category_exist) {
-        $entity = await Country::genCountry($entity_name);
+        $entity = await Country::genCountry($entity_iso_code);
         $category = await Category::genSingleCategoryByName($c);
         await self::genCreate(
           $type,
@@ -163,7 +163,7 @@ class Level extends Model implements Importable, Exportable {
         'title' => $level->getTitle(),
         'active' => $level->getActive(),
         'description' => $level->getDescription(),
-        'entity_name' => $entity->getName(),
+        'entity_iso_code' => $entity->getIsoCode(),
         'category' => $category->getCategory(),
         'points' => $level->getPoints(),
         'bonus' => $level->getBonus(),
@@ -945,15 +945,15 @@ class Level extends Model implements Importable, Exportable {
   public static async function genAlreadyExist(
     string $type,
     string $title,
-    string $entity_name,
+    string $entity_iso_code,
   ): Awaitable<bool> {
     $db = await self::genDb();
 
     $result = await $db->queryf(
-      'SELECT COUNT(*) FROM levels WHERE type = %s AND title = %s AND entity_id IN (SELECT id FROM countries WHERE name = %s)',
+      'SELECT COUNT(*) FROM levels WHERE type = %s AND title = %s AND entity_id IN (SELECT id FROM countries WHERE iso_code = %s)',
       $type,
       $title,
-      $entity_name,
+      $entity_iso_code,
     );
 
     if ($result->numRows() > 0) {


### PR DESCRIPTION
Levels get the country assigned by iso_code, since the names are all going through each translation, fixes #262