### PR TITLE
Fixing missing sudo when provisioning

### DIFF
--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -250,7 +250,7 @@ composer.phar install
 # Install NPM and grunt
 package npm
 package nodejs-legacy
-npm install
+sudo npm install
 sudo npm install -g grunt
 sudo npm install -g flow-bin
 


### PR DESCRIPTION
When provisioning, ```npm install``` was missing a sudo, so there was an error thrown out because some packages were not installed. Fix for #224