### PR TITLE
Updated Memcached Implementation

### DIFF
--- a/src/controllers/ajax/GameAjaxController.php
+++ b/src/controllers/ajax/GameAjaxController.php
@@ -61,10 +61,12 @@ class GameAjaxController extends AjaxController {
             // Update teams last score
             await Team::genLastScore(SessionUtils::sessionTeam());
             //Invalidate score cache
+            MultiTeam::invalidateMCRecords('ALL_TEAMS');
             MultiTeam::invalidateMCRecords('POINTS_BY_TYPE');
             MultiTeam::invalidateMCRecords('LEADERBOARD');
             MultiTeam::invalidateMCRecords('TEAMS_BY_LEVEL');
             MultiTeam::invalidateMCRecords('TEAMS_FIRST_CAP');
+            ScoreLog::invalidateMCRecords('LEVEL_CAPTURES');
             return Utils::ok_response('Success', 'game');
           } else {
             await FailureLog::genLogFailedScore(

--- a/src/controllers/ajax/GameAjaxController.php
+++ b/src/controllers/ajax/GameAjaxController.php
@@ -60,7 +60,7 @@ class GameAjaxController extends AjaxController {
             );
             // Update teams last score
             await Team::genLastScore(SessionUtils::sessionTeam());
-            //Invalidate score cache
+            // Invalidate score cache
             MultiTeam::invalidateMCRecords('ALL_TEAMS');
             MultiTeam::invalidateMCRecords('POINTS_BY_TYPE');
             MultiTeam::invalidateMCRecords('LEADERBOARD');

--- a/src/models/Model.php
+++ b/src/models/Model.php
@@ -41,7 +41,6 @@ abstract class Model {
   protected static function getMCRecords(string $key): mixed {
     $mc = self::getMc();
     $mc_result = $mc->get(static::$MC_KEY.static::$MC_KEYS->get($key));
-    /* HH_IGNORE_ERROR[4110] */
     return $mc_result;
   }
 

--- a/src/models/Model.php
+++ b/src/models/Model.php
@@ -3,6 +3,10 @@
 abstract class Model {
   protected static Db $db = MUST_MODIFY;
   protected static Memcached $mc = MUST_MODIFY;
+  protected static string $MC_KEY = 'MUST_MODIFY';
+  protected static int $MC_EXPIRE = 0; //Defaults to indefinite cache life
+
+  protected static Map<string, string> $MC_KEYS = Map {};
 
   protected static async function genDb(): Awaitable<AsyncMysqlConnection> {
     if (self::$db === MUST_MODIFY) {
@@ -23,5 +27,32 @@ abstract class Model {
       self::$mc->addServer($host, $port);
     }
     return self::$mc;
+  }
+
+  protected static function setMCRecords(string $key, mixed $records): void {
+    $mc = self::getMc();
+    $mc->set(
+      static::$MC_KEY.static::$MC_KEYS->get($key),
+      $records,
+      static::$MC_EXPIRE,
+    );
+  }
+
+  protected static function getMCRecords(string $key): mixed {
+    $mc = self::getMc();
+    $mc_result = $mc->get(static::$MC_KEY.static::$MC_KEYS->get($key));
+    /* HH_IGNORE_ERROR[4110] */
+    return $mc_result;
+  }
+
+  public static function invalidateMCRecords(?string $key = null): void {
+    $mc = self::getMc();
+    if (is_null($key)) {
+      foreach (static::$MC_KEYS as $key_name => $mc_key) {
+        $mc->delete(static::$MC_KEY.static::$MC_KEYS->get($key_name));
+      }
+    } else {
+      $mc->delete(static::$MC_KEY.static::$MC_KEYS->get($key));
+    }
   }
 }

--- a/src/models/Model.php
+++ b/src/models/Model.php
@@ -3,8 +3,8 @@
 abstract class Model {
   protected static Db $db = MUST_MODIFY;
   protected static Memcached $mc = MUST_MODIFY;
-  protected static string $MC_KEY = 'MUST_MODIFY';
-  protected static int $MC_EXPIRE = 0; //Defaults to indefinite cache life
+  protected static string $MC_KEY = MUST_MODIFY;
+  protected static int $MC_EXPIRE = 0; // Defaults to indefinite cache life
 
   protected static Map<string, string> $MC_KEYS = Map {};
 
@@ -47,7 +47,7 @@ abstract class Model {
 
   public static function invalidateMCRecords(?string $key = null): void {
     $mc = self::getMc();
-    if (is_null($key)) {
+    if ($key === null) {
       foreach (static::$MC_KEYS as $key_name => $mc_key) {
         $mc->delete(static::$MC_KEY.static::$MC_KEYS->get($key_name));
       }

--- a/src/models/MultiTeam.php
+++ b/src/models/MultiTeam.php
@@ -30,7 +30,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<Map<int, Team>> {
     $mc_result = self::getMCRecords('ALL_TEAMS');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $all_teams = Map {};
       $teams = await self::genTeamArrayFromDB('SELECT * FROM teams');
       foreach ($teams->items() as $team) {
@@ -58,7 +58,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<array<Team>> {
     $mc_result = self::getMCRecords('LEADERBOARD');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $team_leaderboard = array();
       $teams =
         await self::genTeamArrayFromDB(
@@ -80,7 +80,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<int> {
     $mc_result = self::getMCRecords('POINTS_BY_TYPE');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $points_by_type = Map {};
       $teams =
         await self::genTeamArrayFromDB(
@@ -128,7 +128,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<array<Team>> {
     $mc_result = self::getMCRecords('ALL_ACTIVE_TEAMS');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $all_active_teams = array();
       $teams = await self::genTeamArrayFromDB(
         'SELECT * FROM teams WHERE active = 1 ORDER BY id',
@@ -147,7 +147,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<array<Team>> {
     $mc_result = self::getMCRecords('ALL_VISIBLE_TEAMS');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $all_visible_teams = array();
       $teams = await self::genTeamArrayFromDB(
         'SELECT * FROM teams WHERE visible = 1 AND active = 1 ORDER BY id',
@@ -167,7 +167,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<array<Team>> {
     $mc_result = self::getMCRecords('TEAMS_BY_LOGO');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $db = await self::genDb();
       $all_teams = await self::genAllTeamsCache();
       $teams_by_logo = array();
@@ -194,7 +194,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<array<Team>> {
     $mc_result = self::getMCRecords('TEAMS_BY_LEVEL');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $teams_by_completed_level = array();
       $teams =
         await self::genTeamArrayFromDB(
@@ -224,7 +224,7 @@ class MultiTeam extends Team {
     bool $refresh = false,
   ): Awaitable<Team> {
     $mc_result = self::getMCRecords('TEAMS_FIRST_CAP');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $first_team_captured_by_level = array();
       $teams =
         await self::genTeamArrayFromDB(

--- a/src/models/MultiTeam.php
+++ b/src/models/MultiTeam.php
@@ -2,10 +2,9 @@
 
 class MultiTeam extends Team {
 
-  const int MC_EXPIRE = 60;
-  const string MC_KEY = 'multiteam:';
+  protected static string $MC_KEY = 'multiteam:';
 
-  private static Map<string, string>
+  protected static Map<string, string>
     $MC_KEYS = Map {
       "ALL_TEAMS" => "all_teams",
       "LEADERBOARD" => "leaderboard_teams",
@@ -16,33 +15,6 @@ class MultiTeam extends Team {
       "TEAMS_BY_LEVEL" => "level_teams",
       "TEAMS_FIRST_CAP" => "capture_teams",
     };
-
-  private static function setMCRecords(string $key, mixed $records): void {
-    $mc = self::getMc();
-    $mc->set(
-      self::MC_KEY.self::$MC_KEYS->get($key),
-      $records,
-      self::MC_EXPIRE,
-    );
-  }
-
-  private static function getMCRecords(string $key): mixed {
-    $mc = self::getMc();
-    $mc_result = $mc->get(self::MC_KEY.self::$MC_KEYS->get($key));
-    /* HH_IGNORE_ERROR[4110] */
-    return $mc_result;
-  }
-
-  public static function invalidateMCRecords(?string $key = null): void {
-    $mc = self::getMc();
-    if (is_null($key)) {
-      foreach (self::$MC_KEYS as $name => $mc_key) {
-        $mc->delete(self::MC_KEY.self::$MC_KEYS->get($mc_key));
-      }
-    } else {
-      $mc->delete(self::MC_KEY.self::$MC_KEYS->get($key));
-    }
-  }
 
   private static async function genTeamArrayFromDB(
     string $query,

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -1,6 +1,12 @@
 <?hh // strict
 
 class ScoreLog extends Model {
+
+  protected static string $MC_KEY = 'scorelog:';
+
+  protected static Map<string, string>
+    $MC_KEYS = Map {"LEVEL_CAPTURES" => "capture_teams"};
+
   private function __construct(
     private int $id,
     private string $ts,
@@ -69,28 +75,45 @@ class ScoreLog extends Model {
     int $level_id,
     int $team_id,
     bool $any_team,
+    bool $refresh = false,
   ): Awaitable<bool> {
     $db = await self::genDb();
-
-    if ($any_team) {
-      $result =
-        await $db->queryf(
-          'SELECT COUNT(*) FROM scores_log WHERE level_id = %d AND team_id IN (SELECT id FROM teams WHERE id != %d AND visible = 1)',
-          $level_id,
-          $team_id,
-        );
-    } else {
-      $result =
-        await $db->queryf(
-          'SELECT COUNT(*) FROM scores_log WHERE level_id = %d AND team_id = %d',
-          $level_id,
-          $team_id,
-        );
+    $mc_result = self::getMCRecords('LEVEL_CAPTURES');
+    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+      $level_captures = Map {};
+      $result = await $db->queryf('SELECT level_id, team_id FROM scores_log');
+      foreach ($result->mapRows() as $row) {
+        if ($level_captures->contains(intval($row->get("level_id")))) {
+          $level_capture_teams =
+            $level_captures->get(intval($row->get("level_id")));
+          /* HH_IGNORE_ERROR[4064] */
+          $level_capture_teams->add(intval($row->get("team_id")));
+          $level_captures->set(
+            intval($row->get("level_id")),
+            $level_capture_teams,
+          );
+        } else {
+          $level_capture_teams = Vector {};
+          $level_capture_teams->add(intval($row->get("team_id")));
+          $level_captures->add(
+            Pair {intval($row->get("level_id")), $level_capture_teams},
+          );
+        }
+      }
+      self::setMCRecords('LEVEL_CAPTURES', new Map($level_captures));
     }
-
-    if ($result->numRows() > 0) {
-      invariant($result->numRows() === 1, 'Expected exactly one result');
-      return intval($result->mapRows()[0]['COUNT(*)']) > 0;
+    $level_captures = self::getMCRecords('LEVEL_CAPTURES');
+    if ($level_captures->contains($level_id)) {
+      if ($any_team) {
+        $team_id_key =
+          $level_captures->get($level_id)->linearSearch($team_id);
+        if ($team_id_key != -1) {
+          $level_captures->get($level_id)->removeKey($team_id_key);
+        }
+        return intval(count($level_captures->get($level_id))) > 0;
+      } else {
+        return $level_captures->get($level_id)->linearSearch($team_id) != -1;
+      }
     } else {
       return false;
     }

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -103,15 +103,19 @@ class ScoreLog extends Model {
       self::setMCRecords('LEVEL_CAPTURES', new Map($level_captures));
     }
     $level_captures = self::getMCRecords('LEVEL_CAPTURES');
+    /* HH_IGNORE_ERROR[4062] */
     if ($level_captures->contains($level_id)) {
       if ($any_team) {
-        $team_id_key =
+        $team_id_key = /* HH_IGNORE_ERROR[4062] */
           $level_captures->get($level_id)->linearSearch($team_id);
         if ($team_id_key != -1) {
+          /* HH_IGNORE_ERROR[4062] */
           $level_captures->get($level_id)->removeKey($team_id_key);
         }
+        /* HH_IGNORE_ERROR[4062] */
         return intval(count($level_captures->get($level_id))) > 0;
       } else {
+        /* HH_IGNORE_ERROR[4062] */
         return $level_captures->get($level_id)->linearSearch($team_id) != -1;
       }
     } else {

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -79,7 +79,7 @@ class ScoreLog extends Model {
   ): Awaitable<bool> {
     $db = await self::genDb();
     $mc_result = self::getMCRecords('LEVEL_CAPTURES');
-    if ((!$mc_result) || (count($mc_result) === 0) || ($refresh)) {
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
       $level_captures = Map {};
       $result = await $db->queryf('SELECT level_id, team_id FROM scores_log');
       foreach ($result->mapRows() as $row) {

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -106,7 +106,7 @@ class ScoreLog extends Model {
     /* HH_IGNORE_ERROR[4062] */
     if ($level_captures->contains($level_id)) {
       if ($any_team) {
-        $team_id_key = /* HH_IGNORE_ERROR[4062] */
+        $team_id_key = /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
           $level_captures->get($level_id)->linearSearch($team_id);
         if ($team_id_key != -1) {
           /* HH_IGNORE_ERROR[4062] */

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -225,7 +225,7 @@ class Team extends Model implements Importable, Exportable {
         $logo,
       );
 
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
     invariant($result->numRows() === 1, 'Expected exactly one result');
     return intval($result->mapRows()[0]['id']);
   }
@@ -265,7 +265,7 @@ class Team extends Model implements Importable, Exportable {
         $logo,
       );
 
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
     invariant($result->numRows() === 1, 'Expected exactly one result');
     return intval($result->mapRows()[0]['id']);
   }
@@ -283,7 +283,7 @@ class Team extends Model implements Importable, Exportable {
       $email,
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Get a team data.
@@ -313,7 +313,7 @@ class Team extends Model implements Importable, Exportable {
       $points,
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Update team password.
@@ -327,7 +327,7 @@ class Team extends Model implements Importable, Exportable {
       $password_hash,
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Delete team.
@@ -337,7 +337,7 @@ class Team extends Model implements Importable, Exportable {
       'DELETE FROM teams WHERE id = %d AND protected = 0 LIMIT 1',
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Enable or disable teams by passing 1 or 0.
@@ -351,7 +351,7 @@ class Team extends Model implements Importable, Exportable {
       $status ? 1 : 0,
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Enable or disable all teams by passing 1 or 0.
@@ -361,7 +361,7 @@ class Team extends Model implements Importable, Exportable {
       'UPDATE teams SET active = %d WHERE id > 0 AND protected = 0',
       $status ? 1 : 0,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Sets toggles team admin status.
@@ -375,7 +375,7 @@ class Team extends Model implements Importable, Exportable {
       $admin ? 1 : 0,
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Enable or disable team visibility by passing 1 or 0.
@@ -389,7 +389,7 @@ class Team extends Model implements Importable, Exportable {
       $visible ? 1 : 0,
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Check if a team name is already created.
@@ -547,14 +547,14 @@ class Team extends Model implements Importable, Exportable {
       'UPDATE teams SET last_score = NOW() WHERE id = %d LIMIT 1',
       $team_id,
     );
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Set all points to zero for all teams.
   public static async function genResetAllPoints(): Awaitable<void> {
     $db = await self::genDb();
     await $db->queryf('UPDATE teams SET points = 0 WHERE id > 0');
-    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
+    MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
   // Teams total number.

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -225,6 +225,7 @@ class Team extends Model implements Importable, Exportable {
         $logo,
       );
 
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
     invariant($result->numRows() === 1, 'Expected exactly one result');
     return intval($result->mapRows()[0]['id']);
   }
@@ -264,6 +265,7 @@ class Team extends Model implements Importable, Exportable {
         $logo,
       );
 
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
     invariant($result->numRows() === 1, 'Expected exactly one result');
     return intval($result->mapRows()[0]['id']);
   }
@@ -281,6 +283,7 @@ class Team extends Model implements Importable, Exportable {
       $email,
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Get a team data.
@@ -310,6 +313,7 @@ class Team extends Model implements Importable, Exportable {
       $points,
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Update team password.
@@ -543,12 +547,14 @@ class Team extends Model implements Importable, Exportable {
       'UPDATE teams SET last_score = NOW() WHERE id = %d LIMIT 1',
       $team_id,
     );
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Set all points to zero for all teams.
   public static async function genResetAllPoints(): Awaitable<void> {
     $db = await self::genDb();
     await $db->queryf('UPDATE teams SET points = 0 WHERE id > 0');
+    MultiTeam::invalidateMCRecords(); //Invalidate Memcached MultiTeam data.
   }
 
   // Teams total number.


### PR DESCRIPTION
- Moved setMCRecords(), getMCRecords(), and invalidateMCRecords() to the Model class.  These methods will be utilized in any Model class in which Memcached is implemented.
- MC_KEY, MC_EXPIRE, and MC_KEYS have been converted to protected static properties on the Model class, which can then be overloaded by the children classes.  These static parent properties allow each class to define the relevant Memcached settings needed.
- MC_EXPIRE now defaults to 0 (indefinite), this can be overridden by a child class if the need arises.
- The Memcached for MultiTeam and ScoreLog are invalidated on demand.  This invalidation takes place when teams are modified, created, or deleted and when scoring events are triggered.
- Fixed an issue where the full class cache wasn't being invalidated if no parameter was provided to invalidateMCRecords().
- Updated ScoreLog::genPreviousScore() to reduce queries and utilize Memcached.  Previously the method was calling 2(n) queries per level.  Now the query has been consolidated to a single query, and the data is stored in Memcached and only runs after invalidation on a scoring event.
