### PR TITLE
A simple fix in language.php

### DIFF
--- a/src/language/language.php
+++ b/src/language/language.php
@@ -1,5 +1,4 @@
 <?hh // strict
-require_once ($_SERVER['DOCUMENT_ROOT'].'/../vendor/autoload.php');
 
 /* HH_IGNORE_ERROR[1002] */
 $lang = null;


### PR DESCRIPTION
This fix leads to solve issues #180 , #165 & #169
the progressive.php & bases.php cannot start due to error in "language.php" when run in cli.
The simplest solution compared to PR #259 which is using hardcoded "/var/www/fbctf" 

#hacktoberfest :)