### PR TITLE
Fix formatting of error page glitching.

### DIFF
--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -551,7 +551,7 @@ class IndexController extends Controller {
     return
       <main role="main" class="fb-main page--login full-height fb-scroll">
         <header class="fb-section-header fb-container">
-          <h1 class="fb-glitch" data-text="{tr('ERROR')}">{tr('ERROR')}</h1>
+          <h1 class="fb-glitch" data-text={tr('ERROR')}>{tr('ERROR')}</h1>
         </header>
         <div class="fb-actionable">
           <h1>¯\_(ツ)_/¯</h1>


### PR DESCRIPTION
The current XHP results in the literal string {tr('ERROR')} ending up in the output.  XHP doesn't quote attributes with "".