### PR TITLE
Flag Case Sensitivity Update

### DIFF
--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -671,7 +671,8 @@ class Level extends Model implements Importable, Exportable {
     if ($type === "flag") {
       return trim($level->getFlag()) === trim($answer); // case sensitive
     } else {
-      return strtoupper(trim($level->getFlag())) === strtoupper(trim($answer)); // case insensitive
+      return
+        strtoupper(trim($level->getFlag())) === strtoupper(trim($answer)); // case insensitive
     }
   }
 

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -667,7 +667,12 @@ class Level extends Model implements Importable, Exportable {
     string $answer,
   ): Awaitable<bool> {
     $level = await self::gen($level_id);
-    return strtoupper(trim($level->getFlag())) === strtoupper(trim($answer));
+    $type = $level->getType();
+    if ($type === "flag") {
+      return trim($level->getFlag()) === trim($answer); // case sensitive
+    } else {
+      return strtoupper(trim($level->getFlag())) === strtoupper(trim($answer)); // case insensitive
+    }
   }
 
   // Adjust bonus.

--- a/tests/_files/seed.xml
+++ b/tests/_files/seed.xml
@@ -59,6 +59,40 @@
       <value>1</value>
       <value>2015-04-26 12:14:20</value>
     </row>
+    <row>
+      <value>2</value>
+      <value>1</value>
+      <value>quiz</value>
+      <value>title</value>
+      <value>description</value>
+      <value>1</value>
+      <value>1</value>
+      <value>10</value>
+      <value>1</value>
+      <value>1</value>
+      <value>1</value>
+      <value>quiz</value>
+      <value>hint</value>
+      <value>1</value>
+      <value>2015-04-26 12:14:20</value>
+    </row>
+    <row>
+      <value>3</value>
+      <value>1</value>
+      <value>flag</value>
+      <value>title</value>
+      <value>description</value>
+      <value>1</value>
+      <value>1</value>
+      <value>10</value>
+      <value>1</value>
+      <value>1</value>
+      <value>1</value>
+      <value>flag</value>
+      <value>hint</value>
+      <value>1</value>
+      <value>2015-04-26 12:14:20</value>
+    </row>
   </table>
   <table name="countries">
     <column>id</column>

--- a/tests/models/LevelTest.php
+++ b/tests/models/LevelTest.php
@@ -34,7 +34,7 @@ class LevelTest extends FBCTFTest {
 
     $this->assertEquals(2, $id);
     $all = HH\Asio\join(Level::genAllLevels());
-    $this->assertEquals(2, count($all));
+    $this->assertEquals(4, count($all));
     $l = $all[1];
     $this->assertEquals(2, $l->getId());
     $this->assertFalse($l->getActive());
@@ -68,7 +68,7 @@ class LevelTest extends FBCTFTest {
 
     $this->assertEquals(2, $id);
     $all = HH\Asio\join(Level::genAllLevels());
-    $this->assertEquals(2, count($all));
+    $this->assertEquals(4, count($all));
     $l = $all[1];
     $this->assertEquals(2, $l->getId());
     $this->assertFalse($l->getActive());
@@ -102,7 +102,7 @@ class LevelTest extends FBCTFTest {
     ));
 
     $all = HH\Asio\join(Level::genAllLevels());
-    $this->assertEquals(1, count($all));
+    $this->assertEquals(3, count($all));
     $l = $all[0];
     $this->assertEquals(1, $l->getId());
     $this->assertTrue($l->getActive());
@@ -123,13 +123,13 @@ class LevelTest extends FBCTFTest {
   public function testDelete(): void {
     HH\Asio\join(Level::genDelete(1));
     $all = HH\Asio\join(Level::genAllLevels());
-    $this->assertEquals(0, count($all));
+    $this->assertEquals(2, count($all));
   }
 
   public function testSetStatus(): void {
     HH\Asio\join(Level::genSetStatus(1, false));
     $all = HH\Asio\join(Level::genAllLevels());
-    $this->assertEquals(1, count($all));
+    $this->assertEquals(3, count($all));
     $l = $all[0];
     $this->assertFalse($l->getActive());
   }
@@ -137,7 +137,7 @@ class LevelTest extends FBCTFTest {
   public function testSetStatusType(): void {
     HH\Asio\join(Level::genSetStatusType(false, 'base'));
     $all = HH\Asio\join(Level::genAllLevels());
-    $this->assertEquals(1, count($all));
+    $this->assertEquals(3, count($all));
     $l = $all[0];
     $this->assertEquals('base', $l->getType());
     $this->assertFalse($l->getActive());
@@ -146,7 +146,7 @@ class LevelTest extends FBCTFTest {
   public function testSetStatusAll(): void {
     HH\Asio\join(Level::genSetStatusAll(false, 'base'));
     $all = HH\Asio\join(Level::genAllLevels());
-    $this->assertEquals(1, count($all));
+    $this->assertEquals(3, count($all));
     $l = $all[0];
     $this->assertEquals('base', $l->getType());
     $this->assertFalse($l->getActive());
@@ -154,7 +154,7 @@ class LevelTest extends FBCTFTest {
 
   public function testAllActiveLevels(): void {
     $all = HH\Asio\join(Level::genAllActiveLevels());
-    $this->assertEquals(1, count($all));
+    $this->assertEquals(3, count($all));
   }
 
   public function testAllActiveBases(): void {
@@ -164,12 +164,12 @@ class LevelTest extends FBCTFTest {
 
   public function testAllTypeLevels(): void {
     $all = HH\Asio\join(Level::genAllTypeLevels('flag'));
-    $this->assertEquals(0, count($all));
+    $this->assertEquals(1, count($all));
   }
 
   public function testAll(): void {
     $all = HH\Asio\join(Level::genAllQuizLevels());
-    $this->assertEquals(0, count($all));
+    $this->assertEquals(1, count($all));
     $all = HH\Asio\join(Level::genAllBaseLevels());
     $this->assertEquals(1, count($all));
     $all = HH\Asio\join(Level::genAllFlagLevels());

--- a/tests/models/LevelTest.php
+++ b/tests/models/LevelTest.php
@@ -178,8 +178,14 @@ class LevelTest extends FBCTFTest {
 
   public function testCheckAnswer(): void {
     $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(1, 'no')));
-    $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(1, 'FLAG')));
     $this->assertTrue(HH\Asio\join(Level::genCheckAnswer(1, 'flag')));
+    $this->assertTrue(HH\Asio\join(Level::genCheckAnswer(1, 'FLAG')));
+    $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(2, 'no')));
+    $this->assertTrue(HH\Asio\join(Level::genCheckAnswer(2, 'quiz')));
+    $this->assertTrue(HH\Asio\join(Level::genCheckAnswer(2, 'QUIZ')));
+    $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(3, 'no')));
+    $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(3, 'FLAG')));
+    $this->assertTrue(HH\Asio\join(Level::genCheckAnswer(3, 'flag')));
   }
 
   public function testAdjustBonus(): void {

--- a/tests/models/LevelTest.php
+++ b/tests/models/LevelTest.php
@@ -32,11 +32,11 @@ class LevelTest extends FBCTFTest {
       2, // penalty
     ));
 
-    $this->assertEquals(2, $id);
+    $this->assertEquals(4, $id);
     $all = HH\Asio\join(Level::genAllLevels());
     $this->assertEquals(4, count($all));
-    $l = $all[1];
-    $this->assertEquals(2, $l->getId());
+    $l = $all[3];
+    $this->assertEquals(4, $l->getId());
     $this->assertFalse($l->getActive());
     $this->assertEquals('flag', $l->getType());
     $this->assertEquals('title 2', $l->getTitle());
@@ -66,11 +66,11 @@ class LevelTest extends FBCTFTest {
       2, // penalty
     ));
 
-    $this->assertEquals(2, $id);
+    $this->assertEquals(4, $id);
     $all = HH\Asio\join(Level::genAllLevels());
     $this->assertEquals(4, count($all));
-    $l = $all[1];
-    $this->assertEquals(2, $l->getId());
+    $l = $all[3];
+    $this->assertEquals(4, $l->getId());
     $this->assertFalse($l->getActive());
     $this->assertEquals('flag', $l->getType());
     $this->assertEquals('title 2', $l->getTitle());
@@ -173,7 +173,7 @@ class LevelTest extends FBCTFTest {
     $all = HH\Asio\join(Level::genAllBaseLevels());
     $this->assertEquals(1, count($all));
     $all = HH\Asio\join(Level::genAllFlagLevels());
-    $this->assertEquals(0, count($all));
+    $this->assertEquals(1, count($all));
   }
 
   public function testCheckAnswer(): void {

--- a/tests/models/LevelTest.php
+++ b/tests/models/LevelTest.php
@@ -178,6 +178,7 @@ class LevelTest extends FBCTFTest {
 
   public function testCheckAnswer(): void {
     $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(1, 'no')));
+    $this->assertFlase(HH\Asio\join(Level::genCheckAnswer(1, 'FLAG')));
     $this->assertTrue(HH\Asio\join(Level::genCheckAnswer(1, 'flag')));
   }
 

--- a/tests/models/LevelTest.php
+++ b/tests/models/LevelTest.php
@@ -178,7 +178,7 @@ class LevelTest extends FBCTFTest {
 
   public function testCheckAnswer(): void {
     $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(1, 'no')));
-    $this->assertFlase(HH\Asio\join(Level::genCheckAnswer(1, 'FLAG')));
+    $this->assertFalse(HH\Asio\join(Level::genCheckAnswer(1, 'FLAG')));
     $this->assertTrue(HH\Asio\join(Level::genCheckAnswer(1, 'flag')));
   }
 


### PR DESCRIPTION
* Flags have now been made case sensitivity.  Previously the case was ignored when checking the correctness of a flag answer.

* Added a Unit Test to ensure the flag was only counted as correct when the case matches.