### PR TITLE
Fixed Tests and Build Failure

### DIFF
--- a/tests/_files/seed.xml
+++ b/tests/_files/seed.xml
@@ -99,7 +99,7 @@
       <value>2</value>
       <value>language</value>
       <value>en</value>
-      <value>(String) Language of the system</value></row>
+      <value>(String) Language of the system</value>
     </row>
   </table>
   <table name="categories">

--- a/tests/_files/seed.xml
+++ b/tests/_files/seed.xml
@@ -95,6 +95,12 @@
       <value>value</value>
       <value>description</value>
     </row>
+    <row>
+      <value>2</value>
+      <value>language</value>
+      <value>en</value>
+      <value>(String) Language of the system</value></row>
+    </row>
   </table>
   <table name="categories">
     <column>id</column>

--- a/tests/_files/seed.xml
+++ b/tests/_files/seed.xml
@@ -63,7 +63,6 @@
   <table name="countries">
     <column>id</column>
     <column>iso_code</column>
-    <column>name</column>
     <column>used</column>
     <column>enabled</column>
     <column>d</column>
@@ -71,7 +70,6 @@
     <row>
       <value>1</value>
       <value>BR</value>
-      <value>Brazil</value>
       <value>1</value>
       <value>1</value>
       <value>d</value>
@@ -80,7 +78,6 @@
     <row>
       <value>2</value>
       <value>US</value>
-      <value>United States</value>
       <value>1</value>
       <value>0</value>
       <value>d</value>

--- a/tests/models/ConfigurationTest.php
+++ b/tests/models/ConfigurationTest.php
@@ -4,7 +4,7 @@ class ConfigurationTest extends FBCTFTest {
 
   public function testAllConfiguration(): void {
     $all = HH\Asio\join(Configuration::genAllConfiguration());
-    $this->assertEquals(1, count($all));
+    $this->assertEquals(2, count($all));
 
     $c = $all[0];
     $this->assertEquals(1, $c->getId());


### PR DESCRIPTION
* Removed country name from the unit test seed data. County names are no longer present in the country database. This should fix the failure of the build script and should fix the failure of the unit testing script.

* There may be a few other references to the country name field within the code base. Those too will need to be removed in the future.