### PR TITLE
Announcements have now timestamp and are less clutered

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,2 @@
+[core]
+	filemode = false

--- a/config
+++ b/config
@@ -1,2 +1,0 @@
-[core]
-	filemode = false

--- a/src/inc/gameboard/modules/announcements.php
+++ b/src/inc/gameboard/modules/announcements.php
@@ -15,6 +15,7 @@ class AnnouncementsModuleController {
       foreach ($announcements as $announcement) {
         $announcements_ul->appendChild(
           <li>
+            [ {time_ago($announcement->getTs())} ]
             <span class="announcement-highlight">
               {$announcement->getAnnouncement()}
             </span>

--- a/src/static/css/scss/_gameboard.scss
+++ b/src/static/css/scss/_gameboard.scss
@@ -277,6 +277,17 @@ $module-margin: 20px;
 
     // data-module = leaderboard
 
+    // announcements module
+    &[data-module="announcements"] {
+      .activity-stream li {
+        position: relative;
+        padding: 3px 0 3px 5px;
+        border-bottom: 1px solid $teal-blue;
+      }
+    }
+    
+    // data-module = announcements
+
     // activity module
     &[data-module="activity"] {
       .activity-stream li {


### PR DESCRIPTION
Announcements did not have a proper format and they ended up as clutter and not really helpful. Issue is #213. Now they have the timestamp and separation.