### PR TITLE
Install correct dependencies in dev

### DIFF
--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -221,7 +221,7 @@ package language-pack-en
 
 # Packages to be installed in dev mode
 if [[ "$MODE" == "dev" ]]; then
-    sudo apt-get install -y build-essential curl python-dev python3-dev
+    sudo apt-get install -y build-essential curl python-dev
     package python-pip
     sudo -H pip install mycli
     package emacs

--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -221,6 +221,7 @@ package language-pack-en
 
 # Packages to be installed in dev mode
 if [[ "$MODE" == "dev" ]]; then
+    sudo apt-get install -y build-essential curl python-dev python3-dev
     package python-pip
     sudo -H pip install mycli
     package emacs


### PR DESCRIPTION
Fixes issue #329 by installing dependencies.

Which version of python do we need, 2 or 3? This works with both, but I want to only include what we need.

Reviewers: @javuto 