### PR TITLE
Added Memcached Implementation to Level and Control

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -3341,10 +3341,7 @@ class AdminController extends Controller {
 
           $level = $results->get('level');
           invariant($level !== null, 'Level should not be null');
-          invariant(
-            $level instanceof Level,
-            'level should be of type Level',
-          );
+          invariant($level instanceof Level, 'level should be of type Level');
 
           $country = await Country::gen($level->getEntityId());
 

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -5,7 +5,7 @@ class Control extends Model {
   protected static string $MC_KEY = 'control:';
 
   protected static Map<string, string>
-    $MC_KEYS = Map {"ALL_ACTIVITY" => "activity"};
+    $MC_KEYS = Map {'ALL_ACTIVITY' => 'activity'};
 
   public static async function genStartScriptLog(
     int $pid,
@@ -263,8 +263,12 @@ class Control extends Model {
         );
       self::setMCRecords('ALL_ACTIVITY', $result->mapRows());
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('ALL_ACTIVITY');
+    $all_activity = self::getMCRecords('ALL_ACTIVITY');
+    invariant(
+      $all_activity instanceof Vector,
+      'all_activity should be of type Vector',
+    );
+    return $all_activity;
   }
 
   public static async function genResetBases(): Awaitable<void> {

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -262,13 +262,13 @@ class Control extends Model {
           'SELECT scores_log.ts AS time, teams.name AS team, countries.iso_code AS country, scores_log.team_id AS team_id FROM scores_log, levels, teams, countries WHERE scores_log.level_id = levels.id AND levels.entity_id = countries.id AND scores_log.team_id = teams.id AND teams.visible = 1 ORDER BY time DESC LIMIT 50',
         );
       self::setMCRecords('ALL_ACTIVITY', $result->mapRows());
+      return $result->mapRows();
     }
-    $all_activity = self::getMCRecords('ALL_ACTIVITY');
     invariant(
-      $all_activity instanceof Vector,
-      'all_activity should be of type Vector',
+      $mc_result instanceof Vector,
+      'cache return should be of type Vector',
     );
-    return $all_activity;
+    return $mc_result;
   }
 
   public static async function genResetBases(): Awaitable<void> {

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -1,6 +1,12 @@
 <?hh // strict
 
 class Control extends Model {
+
+  protected static string $MC_KEY = 'control:';
+
+  protected static Map<string, string>
+    $MC_KEYS = Map {"ALL_ACTIVITY" => "activity"};
+
   public static async function genStartScriptLog(
     int $pid,
     string $name,
@@ -246,13 +252,19 @@ class Control extends Model {
   }
 
   public static async function genAllActivity(
+    bool $refresh = false,
   ): Awaitable<Vector<Map<string, string>>> {
-    $db = await self::genDb();
-    $result =
-      await $db->queryf(
-        'SELECT scores_log.ts AS time, teams.name AS team, countries.iso_code AS country, scores_log.team_id AS team_id FROM scores_log, levels, teams, countries WHERE scores_log.level_id = levels.id AND levels.entity_id = countries.id AND scores_log.team_id = teams.id AND teams.visible = 1 ORDER BY time DESC LIMIT 50',
-      );
-    return $result->mapRows();
+    $mc_result = self::getMCRecords('ALL_ACTIVITY');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $db = await self::genDb();
+      $result =
+        await $db->queryf(
+          'SELECT scores_log.ts AS time, teams.name AS team, countries.iso_code AS country, scores_log.team_id AS team_id FROM scores_log, levels, teams, countries WHERE scores_log.level_id = levels.id AND levels.entity_id = countries.id AND scores_log.team_id = teams.id AND teams.visible = 1 ORDER BY time DESC LIMIT 50',
+        );
+      self::setMCRecords('ALL_ACTIVITY', $result->mapRows());
+    }
+    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::getMCRecords('ALL_ACTIVITY');
   }
 
   public static async function genResetBases(): Awaitable<void> {

--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -105,7 +105,7 @@ class Country extends Model {
 
     foreach ($rows as $row) {
       $all_countries->add(
-        Pair {intval($row->get("id")), self::countryFromRow($row)},
+        Pair {intval($row->get('id')), self::countryFromRow($row)},
       );
     }
     invariant(
@@ -236,7 +236,7 @@ class Country extends Model {
       $result = await $db->queryf('SELECT * FROM countries ORDER BY id');
       foreach ($result->mapRows() as $row) {
         $all_countries->add(
-          Pair {intval($row->get("id")), self::countryFromRow($row)},
+          Pair {intval($row->get('id')), self::countryFromRow($row)},
         );
       }
       self::setMCRecords('ALL_COUNTRIES_BY_ID', $all_countries);

--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -240,7 +240,7 @@ class Country extends Model {
       }
       self::setMCRecords('ALL_COUNTRIES_BY_ID', $all_countries);
       invariant(
-        $all_countries->contains($country_id) === false,
+        $all_countries->contains($country_id) !== false,
         'country not found',
       );
       if ($all_countries->contains($country_id)) {
@@ -257,7 +257,7 @@ class Country extends Model {
         'cache return should be a Map of Country by Id',
       );
       invariant(
-        $mc_result->contains($country_id) === false,
+        $mc_result->contains($country_id) !== false,
         'country not found',
       );
       if ($mc_result->contains($country_id)) {

--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -2,12 +2,17 @@
 
 class Country extends Model {
 
-  const string MC_KEY_ALL_COUNTRIES = 'all_countries';
-  const string MC_KEY_ALL_COUNTRIES_FOR_MAP = 'all_countries_for_map';
-  const string
-    MC_KEY_ALL_ENABLED_COUNTRIES = 'all_enabled_countries_for_map';
-  const string
-    MC_KEY_ALL_ENABLED_COUNTRIES_FOR_MAP = 'all_enabled_countries';
+  protected static string $MC_KEY = 'country:';
+
+  protected static Map<string, string>
+    $MC_KEYS = Map {
+      "ALL_COUNTRIES" => "all_countries",
+      "ALL_COUNTRIES_BY_ID" => "all_countries_by_id",
+      "ALL_COUNTRIES_FOR_MAP" => "all_countries_for_map",
+      "ALL_ENABLED_COUNTRIES" => "all_enabled_countries",
+      "ALL_ENABLED_COUNTRIES_FOR_MAP" => "all_enabled_countries_for_map",
+      "ALL_AVAILABLE_COUNTRIES" => "ALL_AVAILABLE_COUNTRIES",
+    };
 
   private function __construct(
     private int $id,
@@ -57,7 +62,7 @@ class Country extends Model {
       'UPDATE countries SET used = 0 WHERE id NOT IN (SELECT entity_id FROM levels)',
     );
 
-    await self::genDeleteAllMemcacheKeys();
+    self::invalidateMCRecords(); // Invalidate Memcached Country data.
   }
 
   // Enable or disable a country
@@ -72,7 +77,7 @@ class Country extends Model {
       $country_id,
     );
 
-    await self::genDeleteAllMemcacheKeys();
+    self::invalidateMCRecords(); // Invalidate Memcached Country data.
   }
 
   // Set the used flag for a country
@@ -87,31 +92,28 @@ class Country extends Model {
       $country_id,
     );
 
-    await self::genDeleteAllMemcacheKeys();
+    self::invalidateMCRecords(); // Invalidate Memcached Country data.
   }
 
   private static async function genAll(
     string $sql,
-    string $mcKey,
   ): Awaitable<array<Country>> {
-    $mc = self::getMc();
-    $mc_result = $mc->get($mcKey);
+    $db = await self::genDb();
+    $all_countries = Map {};
+    /* HH_IGNORE_ERROR[4110] */
+    /* HH_IGNORE_ERROR[4027]: This is safe not being a literal string */
+    $db_result = await $db->queryf($sql);
+    $rows = $db_result->mapRows();
 
-    if ($mc_result) {
-      $rows = $mc_result;
-    } else {
-      $db = await self::genDb();
-      /* HH_IGNORE_ERROR[4110] */
-      /* HH_IGNORE_ERROR[4027] This is safe not being a literal string */
-      $db_result = await $db->queryf($sql);
-      $rows = array_map($map ==> $map->toArray(), $db_result->mapRows());
-      $mc->set($mcKey, $rows);
+    foreach ($rows as $row) {
+      $all_countries->add(
+        Pair {intval($row->get("id")), self::countryFromRow($row)},
+      );
     }
 
     $countries = array();
-    foreach ($rows as $row) {
-      $countries[] = await self::countryFromRow($row);
-    }
+    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    $countries = $all_countries->toValuesArray();
 
     usort(
       $countries,
@@ -123,91 +125,107 @@ class Country extends Model {
     return $countries;
   }
 
-  public static async function genAllCountries(): Awaitable<array<Country>> {
-    return await self::genAll(
-      'SELECT * FROM countries ORDER BY iso_code',
-      self::MC_KEY_ALL_COUNTRIES,
-    );
+  public static async function genAllCountries(
+    bool $refresh = false,
+  ): Awaitable<array<Country>> {
+    $mc_result = self::getMCRecords('ALL_COUNTRIES');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $all_countries =
+        await self::genAll('SELECT * FROM countries ORDER BY iso_code');
+      self::setMCRecords('ALL_COUNTRIES', $all_countries);
+    }
+    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::getMCRecords('ALL_COUNTRIES');
   }
 
   public static async function genAllCountriesForMap(
+    bool $refresh = false,
   ): Awaitable<array<Country>> {
-    return await self::genAll(
-      'SELECT * FROM countries ORDER BY CHAR_LENGTH(d)',
-      self::MC_KEY_ALL_COUNTRIES_FOR_MAP,
-    );
+    $mc_result = self::getMCRecords('ALL_COUNTRIES_FOR_MAP');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $all_countries =
+        await self::genAll('SELECT * FROM countries ORDER BY CHAR_LENGTH(d)');
+      self::setMCRecords('ALL_COUNTRIES_FOR_MAP', $all_countries);
+    }
+    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::getMCRecords('ALL_COUNTRIES_FOR_MAP');
   }
 
   public static async function genAllEnabledCountries(
+    bool $refresh = false,
   ): Awaitable<array<Country>> {
-    return await self::genAll(
-      'SELECT * FROM countries WHERE enabled = 1',
-      self::MC_KEY_ALL_ENABLED_COUNTRIES,
-    );
+    $mc_result = self::getMCRecords('ALL_ENABLED_COUNTRIES');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $all_countries =
+        await self::genAll('SELECT * FROM countries WHERE enabled = 1');
+      self::setMCRecords('ALL_ENABLED_COUNTRIES', $all_countries);
+    }
+    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::getMCRecords('ALL_ENABLED_COUNTRIES');
   }
 
   // All enabled countries. The weird sorting is because SVG lack of z-index
   // and things looking like shit in the map. See issue #20.
   public static async function genAllEnabledCountriesForMap(
+    bool $refresh = false,
   ): Awaitable<array<Country>> {
-    return await self::genAll(
-      'SELECT * FROM countries WHERE enabled = 1 ORDER BY CHAR_LENGTH(d)',
-      self::MC_KEY_ALL_ENABLED_COUNTRIES_FOR_MAP,
-    );
+    $mc_result = self::getMCRecords('ALL_ENABLED_COUNTRIES_FOR_MAP');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $all_countries = await self::genAll(
+        'SELECT * FROM countries WHERE enabled = 1 ORDER BY CHAR_LENGTH(d)',
+      );
+      self::setMCRecords('ALL_ENABLED_COUNTRIES_FOR_MAP', $all_countries);
+    }
+    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::getMCRecords('ALL_ENABLED_COUNTRIES_FOR_MAP');
   }
 
   // All enabled and unused countries
   public static async function genAllAvailableCountries(
+    bool $refresh = false,
   ): Awaitable<array<Country>> {
-    $db = await self::genDb();
-
-    $result = await $db->queryf(
-      'SELECT * FROM countries WHERE enabled = 1 AND used = 0',
-    );
-
-    $countries = array();
-    foreach ($result->mapRows() as $row) {
-      $countries[] = await self::countryFromRow($row->toArray());
+    $mc_result = self::getMCRecords('ALL_AVAILABLE_COUNTRIES');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $all_countries = await self::genAll(
+        'SELECT * FROM countries WHERE enabled = 1 AND used = 0',
+      );
+      self::setMCRecords('ALL_AVAILABLE_COUNTRIES', $all_countries);
     }
-
-    usort(
-      $countries,
-      function($a, $b) {
-        return strcmp($a->name, $b->name);
-      },
-    );
-
-    return $countries;
+    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::getMCRecords('ALL_AVAILABLE_COUNTRIES');
   }
 
   // Check if country is in an active level
   public static async function genIsActiveLevel(
     int $country_id,
   ): Awaitable<bool> {
-    $db = await self::genDb();
-
-    $result = await $db->queryf(
-      'SELECT COUNT(*) FROM levels WHERE entity_id = %d AND active = 1',
-      $country_id,
-    );
-
-    invariant($result->numRows() === 1, 'Expected exactly one result');
-    return intval(firstx($result->mapRows())['COUNT(*)']) > 0;
+    return Level::genWhoUses($country_id) != null;
   }
 
   // Get a country by id.
-  public static async function gen(int $country_id): Awaitable<Country> {
-    $db = await self::genDb();
-
-    $result = await $db->queryf(
-      'SELECT * FROM countries WHERE id = %d LIMIT 1',
-      $country_id,
-    );
-
-    invariant($result->numRows() === 1, 'Expected exactly one result');
-    $new_country =
-      await self::countryFromRow(firstx($result->mapRows())->toArray());
-    return $new_country;
+  /* HH_IGNORE_ERROR[4110]: HHVM is concerned that the dountry might not be present, this is verified by the caller */
+  public static async function gen(
+    int $country_id,
+    bool $refresh = false,
+  ): Awaitable<Country> {
+    $mc_result = self::getMCRecords('ALL_COUNTRIES_BY_ID');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $db = await self::genDb();
+      $all_countries = Map {};
+      $result = await $db->queryf('SELECT * FROM countries ORDER BY id');
+      foreach ($result->mapRows() as $row) {
+        $all_countries->add(
+          Pair {intval($row->get("id")), self::countryFromRow($row)},
+        );
+      }
+      self::setMCRecords('ALL_COUNTRIES_BY_ID', $all_countries);
+    }
+    $countries = self::getMCRecords('ALL_COUNTRIES_BY_ID');
+    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    if ($countries->contains($country_id)) {
+      /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+      return $countries->get($country_id);
+    }
   }
 
   // Get a country by iso_code.
@@ -221,7 +239,8 @@ class Country extends Model {
     );
 
     invariant($result->numRows() === 1, 'Expected exactly one result');
-    return await self::countryFromRow(firstx($result->mapRows())->toArray());
+    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::countryFromRow($result->mapRows());
   }
 
   // Get a random enabled, unused country ID
@@ -237,10 +256,8 @@ class Country extends Model {
     return intval(firstx($result->mapRows())['id']);
   }
 
-  private static async function countryFromRow(
-    array<string, string> $row,
-  ): Awaitable<Country> {
-    $config = await Configuration::gen('language');
+  private static function countryFromRow(Map<string, string> $row): Country {
+    $config = \HH\Asio\join(Configuration::gen('language'));
     $language = $config->getValue();
     $translated_name = locale_get_display_region(
       '-'.must_have_idx($row, 'iso_code'),
@@ -276,11 +293,4 @@ class Country extends Model {
     }
   }
 
-  private static async function genDeleteAllMemcacheKeys(): Awaitable<void> {
-    $mc = self::getMc();
-    $mc->delete(self::MC_KEY_ALL_COUNTRIES);
-    $mc->delete(self::MC_KEY_ALL_COUNTRIES_FOR_MAP);
-    $mc->delete(self::MC_KEY_ALL_ENABLED_COUNTRIES);
-    $mc->delete(self::MC_KEY_ALL_ENABLED_COUNTRIES_FOR_MAP);
-  }
 }

--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -223,7 +223,6 @@ class Country extends Model {
   }
 
   // Get a country by id.
-  /* HH_IGNORE_ERROR[4110]: Lines #246 and #260 prevent this function from failing to return */
   public static async function gen(
     int $country_id,
     bool $refresh = false,
@@ -243,14 +242,12 @@ class Country extends Model {
         $all_countries->contains($country_id) !== false,
         'country not found',
       );
-      if ($all_countries->contains($country_id)) {
-        $country = $all_countries->get($country_id);
-        invariant(
-          $country instanceof Country,
-          'country should be of type Country',
-        );
-        return $country;
-      }
+      $country = $all_countries->get($country_id);
+      invariant(
+        $country instanceof Country,
+        'country should be of type Country',
+      );
+      return $country;
     } else {
       invariant(
         $mc_result instanceof Map,
@@ -260,14 +257,12 @@ class Country extends Model {
         $mc_result->contains($country_id) !== false,
         'country not found',
       );
-      if ($mc_result->contains($country_id)) {
-        $country = $mc_result->get($country_id);
-        invariant(
-          $country instanceof Country,
-          'country should be of type Country',
-        );
-        return $country;
-      }
+      $country = $mc_result->get($country_id);
+      invariant(
+        $country instanceof Country,
+        'country should be of type Country',
+      );
+      return $country;
     }
   }
 

--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -6,12 +6,12 @@ class Country extends Model {
 
   protected static Map<string, string>
     $MC_KEYS = Map {
-      "ALL_COUNTRIES" => "all_countries",
-      "ALL_COUNTRIES_BY_ID" => "all_countries_by_id",
-      "ALL_COUNTRIES_FOR_MAP" => "all_countries_for_map",
-      "ALL_ENABLED_COUNTRIES" => "all_enabled_countries",
-      "ALL_ENABLED_COUNTRIES_FOR_MAP" => "all_enabled_countries_for_map",
-      "ALL_AVAILABLE_COUNTRIES" => "ALL_AVAILABLE_COUNTRIES",
+      'ALL_COUNTRIES' => 'all_countries',
+      'ALL_COUNTRIES_BY_ID' => 'all_countries_by_id',
+      'ALL_COUNTRIES_FOR_MAP' => 'all_countries_for_map',
+      'ALL_ENABLED_COUNTRIES' => 'all_enabled_countries',
+      'ALL_ENABLED_COUNTRIES_FOR_MAP' => 'all_enabled_countries_for_map',
+      'ALL_AVAILABLE_COUNTRIES' => 'ALL_AVAILABLE_COUNTRIES',
     };
 
   private function __construct(
@@ -100,9 +100,7 @@ class Country extends Model {
   ): Awaitable<array<Country>> {
     $db = await self::genDb();
     $all_countries = Map {};
-    /* HH_IGNORE_ERROR[4110] */
-    /* HH_IGNORE_ERROR[4027]: This is safe not being a literal string */
-    $db_result = await $db->queryf($sql);
+    $db_result = await $db->query($sql);
     $rows = $db_result->mapRows();
 
     foreach ($rows as $row) {
@@ -110,9 +108,12 @@ class Country extends Model {
         Pair {intval($row->get("id")), self::countryFromRow($row)},
       );
     }
+    invariant(
+      $all_countries instanceof Map,
+      'all_countries should be a Map of Country',
+    );
 
     $countries = array();
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
     $countries = $all_countries->toValuesArray();
 
     usort(
@@ -134,8 +135,12 @@ class Country extends Model {
         await self::genAll('SELECT * FROM countries ORDER BY iso_code');
       self::setMCRecords('ALL_COUNTRIES', $all_countries);
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('ALL_COUNTRIES');
+    $all_countries = self::getMCRecords('ALL_COUNTRIES');
+    invariant(
+      is_array($all_countries),
+      'all_countries should be an array of Country',
+    );
+    return $all_countries;
   }
 
   public static async function genAllCountriesForMap(
@@ -147,8 +152,12 @@ class Country extends Model {
         await self::genAll('SELECT * FROM countries ORDER BY CHAR_LENGTH(d)');
       self::setMCRecords('ALL_COUNTRIES_FOR_MAP', $all_countries);
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('ALL_COUNTRIES_FOR_MAP');
+    $all_countries = self::getMCRecords('ALL_COUNTRIES_FOR_MAP');
+    invariant(
+      is_array($all_countries),
+      'all_countries should be an array of Country',
+    );
+    return $all_countries;
   }
 
   public static async function genAllEnabledCountries(
@@ -160,8 +169,12 @@ class Country extends Model {
         await self::genAll('SELECT * FROM countries WHERE enabled = 1');
       self::setMCRecords('ALL_ENABLED_COUNTRIES', $all_countries);
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('ALL_ENABLED_COUNTRIES');
+    $all_countries = self::getMCRecords('ALL_ENABLED_COUNTRIES');
+    invariant(
+      is_array($all_countries),
+      'all_countries should be an array of Country',
+    );
+    return $all_countries;
   }
 
   // All enabled countries. The weird sorting is because SVG lack of z-index
@@ -176,8 +189,12 @@ class Country extends Model {
       );
       self::setMCRecords('ALL_ENABLED_COUNTRIES_FOR_MAP', $all_countries);
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('ALL_ENABLED_COUNTRIES_FOR_MAP');
+    $all_countries = self::getMCRecords('ALL_ENABLED_COUNTRIES_FOR_MAP');
+    invariant(
+      is_array($all_countries),
+      'all_countries should be an array of Country',
+    );
+    return $all_countries;
   }
 
   // All enabled and unused countries
@@ -191,8 +208,12 @@ class Country extends Model {
       );
       self::setMCRecords('ALL_AVAILABLE_COUNTRIES', $all_countries);
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('ALL_AVAILABLE_COUNTRIES');
+    $all_countries = self::getMCRecords('ALL_AVAILABLE_COUNTRIES');
+    invariant(
+      is_array($all_countries),
+      'all_countries should be an array of Country',
+    );
+    return $all_countries;
   }
 
   // Check if country is in an active level
@@ -203,7 +224,7 @@ class Country extends Model {
   }
 
   // Get a country by id.
-  /* HH_IGNORE_ERROR[4110]: HHVM is concerned that the dountry might not be present, this is verified by the caller */
+  /* HH_IGNORE_ERROR[4110]: Claims - It is incompatible with void because this async function implicitly returns Awaitable<void>, yet this returns Awaitable<Country> and the type is checked on line 230 */
   public static async function gen(
     int $country_id,
     bool $refresh = false,
@@ -221,10 +242,17 @@ class Country extends Model {
       self::setMCRecords('ALL_COUNTRIES_BY_ID', $all_countries);
     }
     $countries = self::getMCRecords('ALL_COUNTRIES_BY_ID');
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant(
+      $countries instanceof Map,
+      'countries should be a Map of Country by Id',
+    );
     if ($countries->contains($country_id)) {
-      /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-      return $countries->get($country_id);
+      $country = $countries->get($country_id);
+      invariant(
+        $country instanceof Country,
+        'country should be of type Country',
+      );
+      return $country;
     }
   }
 
@@ -239,8 +267,7 @@ class Country extends Model {
     );
 
     invariant($result->numRows() === 1, 'Expected exactly one result');
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::countryFromRow($result->mapRows());
+    return self::countryFromRow($result->mapRows()[0]);
   }
 
   // Get a random enabled, unused country ID

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -833,7 +833,10 @@ class Level extends Model implements Importable, Exportable {
         $all_levels->contains($level_id) !== false,
         'level not found',
       );
-      invariant($all_levels->contains($level_id) !== false, 'level not found');
+      invariant(
+        $all_levels->contains($level_id) !== false,
+        'level not found',
+      );
       $level = $all_levels->get($level_id);
       invariant($level instanceof Level, 'level should be of type Level');
       return $level;

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -125,20 +125,21 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('LEVEL_BY_COUNTRY', $level_by_country);
-    }
-    $level_by_country = self::getMCRecords('LEVEL_BY_COUNTRY');
-    invariant(
-      $level_by_country !== null,
-      'level_by_country should not be null',
-    );
-    invariant(
-      $level_by_country instanceof Map,
-      'level_by_country should be of type Map',
-    );
-    if ($level_by_country->contains($country_id)) {
-      return $level_by_country->get($country_id);
+      if ($level_by_country->contains($country_id)) {
+        return $level_by_country->get($country_id);
+      } else {
+        return null;
+      }
     } else {
-      return null;
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      if ($mc_result->contains($country_id)) {
+        return $mc_result->get($country_id);
+      } else {
+        return null;
+      }
     }
   }
 
@@ -223,17 +224,21 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
-    }
-    $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
-    invariant($active_levels !== null, 'active_levels should not be null');
-    invariant(
-      $active_levels instanceof Map,
-      'active_levels should be of type Map',
-    );
-    if ($active_levels->contains($level_id)) {
-      return true;
+      if ($active_levels->contains($level_id)) {
+        return true;
+      } else {
+        return false;
+      }
     } else {
-      return false;
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      if ($mc_result->contains($level_id)) {
+        return true;
+      } else {
+        return false;
+      }
     }
   }
 
@@ -255,23 +260,33 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
-    }
-    $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
-    invariant($active_levels !== null, 'active_levels should not be null');
-    invariant(
-      $active_levels instanceof Map,
-      'active_levels should be of type Map',
-    );
-    if ($active_levels->contains($level_id)) {
-      $level = $active_levels->get($level_id);
-      invariant($level !== null, 'level should not be null');
-      if ($level->type == 'base') {
-        return true;
+      if ($active_levels->contains($level_id)) {
+        $level = $active_levels->get($level_id);
+        invariant($level instanceof Level, 'level should be type of Level');
+        if ($level->type == 'base') {
+          return true;
+        } else {
+          return false;
+        }
       } else {
         return false;
       }
     } else {
-      return false;
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      if ($mc_result->contains($level_id)) {
+        $level = $mc_result->get($level_id);
+        invariant($level instanceof Level, 'level should be type of Level');
+        if ($level->type == 'base') {
+          return true;
+        } else {
+          return false;
+        }
+      } else {
+        return false;
+      }
     }
   }
 
@@ -653,12 +668,18 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('ALL_LEVELS', new Map($all_levels));
+      $levels = array();
+      $levels = $all_levels->toValuesArray();
+      return $levels;
+    } else {
+      $levels = array();
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      $levels = $mc_result->toValuesArray();
+      return $levels;
     }
-    $all_levels = self::getMCRecords('ALL_LEVELS');
-    $levels = array();
-    invariant($all_levels instanceof Map, 'all_levels should be of type Map');
-    $levels = $all_levels->toValuesArray();
-    return $levels;
   }
 
   // All levels by status.
@@ -678,15 +699,18 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
+      $levels = array();
+      $levels = $active_levels->toValuesArray();
+      return $levels;
+    } else {
+      $levels = array();
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      $levels = $mc_result->toValuesArray();
+      return $levels;
     }
-    $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
-    $levels = array();
-    invariant(
-      $active_levels instanceof Map,
-      'active_levels should be of type Map',
-    );
-    $levels = $active_levels->toValuesArray();
-    return $levels;
   }
 
   // All levels by status.
@@ -706,21 +730,30 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
-    }
-    $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
-    $levels = array();
-    invariant(
-      $active_levels instanceof Map,
-      'active_levels should be of type Map',
-    );
-    $levels = $active_levels->toValuesArray();
-    $bases = array();
-    foreach ($levels as $level) {
-      if ($level->type === 'base') {
-        $bases[] = $level;
+      $levels = array();
+      $levels = $active_levels->toValuesArray();
+      $bases = array();
+      foreach ($levels as $level) {
+        if ($level->type === 'base') {
+          $bases[] = $level;
+        }
       }
+      return $bases;
+    } else {
+      $levels = array();
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      $levels = $mc_result->toValuesArray();
+      $bases = array();
+      foreach ($levels as $level) {
+        if ($level->type === 'base') {
+          $bases[] = $level;
+        }
+      }
+      return $bases;
     }
-    return $bases;
   }
 
   // All levels by type.
@@ -739,18 +772,30 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('ALL_LEVELS', $all_levels);
-    }
-    $all_levels = self::getMCRecords('ALL_LEVELS');
-    $levels = array();
-    invariant($all_levels instanceof Map, 'all_levels should be of type Map');
-    $levels = $all_levels->toValuesArray();
-    $type_levels = array();
-    foreach ($levels as $level) {
-      if ($level->type === $type) {
-        $type_levels[] = $level;
+      $levels = array();
+      $levels = $all_levels->toValuesArray();
+      $type_levels = array();
+      foreach ($levels as $level) {
+        if ($level->type === $type) {
+          $type_levels[] = $level;
+        }
       }
+      return $type_levels;
+    } else {
+      $levels = array();
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      $levels = $mc_result->toValuesArray();
+      $type_levels = array();
+      foreach ($levels as $level) {
+        if ($level->type === $type) {
+          $type_levels[] = $level;
+        }
+      }
+      return $type_levels;
     }
-    return $type_levels;
   }
 
   // All quiz levels.
@@ -769,7 +814,7 @@ class Level extends Model implements Importable, Exportable {
   }
 
   // Get a single level.
-  /* HH_IGNORE_ERROR[4110]: Claims - It is incompatible with void because this async function implicitly returns Awaitable<void>, yet this returns Awaitable<Level> and the type is checked on line 778 */
+  /* HH_IGNORE_ERROR[4110]: Lines #827 and #835 prevent this function from failing to return */
   public static async function gen(
     int $level_id,
     bool $refresh = false,
@@ -785,15 +830,26 @@ class Level extends Model implements Importable, Exportable {
         );
       }
       self::setMCRecords('ALL_LEVELS', $all_levels);
-    }
-    $all_levels = self::getMCRecords('ALL_LEVELS');
-
-    invariant($all_levels !== null, 'all_levels should not be null');
-    invariant($all_levels instanceof Map, 'all_levels should be of type Map');
-    if ($all_levels->contains($level_id)) {
-      $level = $all_levels->get($level_id);
-      invariant($level instanceof Level, 'level should be of type Level');
-      return $level;
+      invariant(
+        $all_levels->contains($level_id) === false,
+        'level not found',
+      );
+      if ($all_levels->contains($level_id)) {
+        $level = $all_levels->get($level_id);
+        invariant($level instanceof Level, 'level should be of type Level');
+        return $level;
+      }
+    } else {
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      invariant($mc_result->contains($level_id) === false, 'level not found');
+      if ($mc_result->contains($level_id)) {
+        $level = $mc_result->get($level_id);
+        invariant($level instanceof Level, 'level should be of type Level');
+        return $level;
+      }
     }
   }
 

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -6,9 +6,9 @@ class Level extends Model implements Importable, Exportable {
 
   protected static Map<string, string>
     $MC_KEYS = Map {
-      "LEVEL_BY_COUNTRY" => "level_by_country",
-      "ALL_LEVELS" => "all_levels",
-      "ALL_ACTIVE_LEVELS" => "active_levels",
+      'LEVEL_BY_COUNTRY' => 'level_by_country',
+      'ALL_LEVELS' => 'all_levels',
+      'ALL_ACTIVE_LEVELS' => 'active_levels',
     };
 
   private function __construct(
@@ -127,9 +127,15 @@ class Level extends Model implements Importable, Exportable {
       self::setMCRecords('LEVEL_BY_COUNTRY', $level_by_country);
     }
     $level_by_country = self::getMCRecords('LEVEL_BY_COUNTRY');
-    /* HH_IGNORE_ERROR[4062] */
+    invariant(
+      $level_by_country !== null,
+      'level_by_country should not be null',
+    );
+    invariant(
+      $level_by_country instanceof Map,
+      'level_by_country should be of type Map',
+    );
     if ($level_by_country->contains($country_id)) {
-      /* HH_IGNORE_ERROR[4062] */
       return $level_by_country->get($country_id);
     } else {
       return null;
@@ -219,9 +225,12 @@ class Level extends Model implements Importable, Exportable {
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
     }
     $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
-    /* HH_IGNORE_ERROR[4062] */
+    invariant($active_levels !== null, 'active_levels should not be null');
+    invariant(
+      $active_levels instanceof Map,
+      'active_levels should be of type Map',
+    );
     if ($active_levels->contains($level_id)) {
-      /* HH_IGNORE_ERROR[4062] */
       return true;
     } else {
       return false;
@@ -248,10 +257,15 @@ class Level extends Model implements Importable, Exportable {
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
     }
     $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
-    /* HH_IGNORE_ERROR[4062] */
+    invariant($active_levels !== null, 'active_levels should not be null');
+    invariant(
+      $active_levels instanceof Map,
+      'active_levels should be of type Map',
+    );
     if ($active_levels->contains($level_id)) {
-      /* HH_IGNORE_ERROR[4062] */
-      if ($active_levels->get($level_id)->type == 'base') {
+      $level = $active_levels->get($level_id);
+      invariant($level !== null, 'level should not be null');
+      if ($level->type == 'base') {
         return true;
       } else {
         return false;
@@ -642,7 +656,7 @@ class Level extends Model implements Importable, Exportable {
     }
     $all_levels = self::getMCRecords('ALL_LEVELS');
     $levels = array();
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant($all_levels instanceof Map, 'all_levels should be of type Map');
     $levels = $all_levels->toValuesArray();
     return $levels;
   }
@@ -667,7 +681,10 @@ class Level extends Model implements Importable, Exportable {
     }
     $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
     $levels = array();
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant(
+      $active_levels instanceof Map,
+      'active_levels should be of type Map',
+    );
     $levels = $active_levels->toValuesArray();
     return $levels;
   }
@@ -692,7 +709,10 @@ class Level extends Model implements Importable, Exportable {
     }
     $active_levels = self::getMCRecords('ALL_ACTIVE_LEVELS');
     $levels = array();
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant(
+      $active_levels instanceof Map,
+      'active_levels should be of type Map',
+    );
     $levels = $active_levels->toValuesArray();
     $bases = array();
     foreach ($levels as $level) {
@@ -722,7 +742,7 @@ class Level extends Model implements Importable, Exportable {
     }
     $all_levels = self::getMCRecords('ALL_LEVELS');
     $levels = array();
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant($all_levels instanceof Map, 'all_levels should be of type Map');
     $levels = $all_levels->toValuesArray();
     $type_levels = array();
     foreach ($levels as $level) {
@@ -749,7 +769,7 @@ class Level extends Model implements Importable, Exportable {
   }
 
   // Get a single level.
-  /* HH_IGNORE_ERROR[4110]: HHVM is concerned that the level might not be present, this is verified by the caller */
+  /* HH_IGNORE_ERROR[4110]: Claims - It is incompatible with void because this async function implicitly returns Awaitable<void>, yet this returns Awaitable<Level> and the type is checked on line 778 */
   public static async function gen(
     int $level_id,
     bool $refresh = false,
@@ -768,10 +788,12 @@ class Level extends Model implements Importable, Exportable {
     }
     $all_levels = self::getMCRecords('ALL_LEVELS');
 
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant($all_levels !== null, 'all_levels should not be null');
+    invariant($all_levels instanceof Map, 'all_levels should be of type Map');
     if ($all_levels->contains($level_id)) {
-      /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-      return $all_levels->get($level_id);
+      $level = $all_levels->get($level_id);
+      invariant($level instanceof Level, 'level should be of type Level');
+      return $level;
     }
   }
 

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -831,7 +831,7 @@ class Level extends Model implements Importable, Exportable {
       }
       self::setMCRecords('ALL_LEVELS', $all_levels);
       invariant(
-        $all_levels->contains($level_id) === false,
+        $all_levels->contains($level_id) !== false,
         'level not found',
       );
       if ($all_levels->contains($level_id)) {
@@ -844,7 +844,7 @@ class Level extends Model implements Importable, Exportable {
         $mc_result instanceof Map,
         'cache return should be of type Map',
       );
-      invariant($mc_result->contains($level_id) === false, 'level not found');
+      invariant($mc_result->contains($level_id) !== false, 'level not found');
       if ($mc_result->contains($level_id)) {
         $level = $mc_result->get($level_id);
         invariant($level instanceof Level, 'level should be of type Level');

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -121,7 +121,7 @@ class Level extends Model implements Importable, Exportable {
       $result = await $db->queryf('SELECT * FROM levels WHERE active = 1');
       foreach ($result->mapRows() as $row) {
         $level_by_country->add(
-          Pair {intval($row->get("entity_id")), self::levelFromRow($row)},
+          Pair {intval($row->get('entity_id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('LEVEL_BY_COUNTRY', $level_by_country);
@@ -219,7 +219,7 @@ class Level extends Model implements Importable, Exportable {
       );
       foreach ($result->mapRows() as $row) {
         $active_levels->add(
-          Pair {intval($row->get("id")), self::levelFromRow($row)},
+          Pair {intval($row->get('id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
@@ -251,7 +251,7 @@ class Level extends Model implements Importable, Exportable {
       );
       foreach ($result->mapRows() as $row) {
         $active_levels->add(
-          Pair {intval($row->get("id")), self::levelFromRow($row)},
+          Pair {intval($row->get('id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
@@ -567,7 +567,7 @@ class Level extends Model implements Importable, Exportable {
     await Country::genUsedAdjust();
 
     self::invalidateMCRecords(); // Invalidate Memcached Level data.
-    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
   }
 
   // Delete level.
@@ -649,7 +649,7 @@ class Level extends Model implements Importable, Exportable {
       $result = await $db->queryf('SELECT * FROM levels ORDER BY id');
       foreach ($result->mapRows() as $row) {
         $all_levels->add(
-          Pair {intval($row->get("id")), self::levelFromRow($row)},
+          Pair {intval($row->get('id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('ALL_LEVELS', new Map($all_levels));
@@ -674,7 +674,7 @@ class Level extends Model implements Importable, Exportable {
       );
       foreach ($result->mapRows() as $row) {
         $active_levels->add(
-          Pair {intval($row->get("id")), self::levelFromRow($row)},
+          Pair {intval($row->get('id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
@@ -702,7 +702,7 @@ class Level extends Model implements Importable, Exportable {
       );
       foreach ($result->mapRows() as $row) {
         $active_levels->add(
-          Pair {intval($row->get("id")), self::levelFromRow($row)},
+          Pair {intval($row->get('id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('ALL_ACTIVE_LEVELS', $active_levels);
@@ -735,7 +735,7 @@ class Level extends Model implements Importable, Exportable {
       $result = await $db->queryf('SELECT * FROM levels ORDER BY id');
       foreach ($result->mapRows() as $row) {
         $all_levels->add(
-          Pair {intval($row->get("id")), self::levelFromRow($row)},
+          Pair {intval($row->get('id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('ALL_LEVELS', $all_levels);
@@ -781,7 +781,7 @@ class Level extends Model implements Importable, Exportable {
       $result = await $db->queryf('SELECT * FROM levels ORDER BY id');
       foreach ($result->mapRows() as $row) {
         $all_levels->add(
-          Pair {intval($row->get("id")), self::levelFromRow($row)},
+          Pair {intval($row->get('id')), self::levelFromRow($row)},
         );
       }
       self::setMCRecords('ALL_LEVELS', $all_levels);

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -279,7 +279,7 @@ class Level extends Model implements Importable, Exportable {
       if ($mc_result->contains($level_id)) {
         $level = $mc_result->get($level_id);
         invariant($level instanceof Level, 'level should be type of Level');
-        if ($level->type == 'base') {
+        if ($level->type === 'base') {
           return true;
         } else {
           return false;
@@ -814,7 +814,6 @@ class Level extends Model implements Importable, Exportable {
   }
 
   // Get a single level.
-  /* HH_IGNORE_ERROR[4110]: Lines #827 and #835 prevent this function from failing to return */
   public static async function gen(
     int $level_id,
     bool $refresh = false,
@@ -834,22 +833,19 @@ class Level extends Model implements Importable, Exportable {
         $all_levels->contains($level_id) !== false,
         'level not found',
       );
-      if ($all_levels->contains($level_id)) {
-        $level = $all_levels->get($level_id);
-        invariant($level instanceof Level, 'level should be of type Level');
-        return $level;
-      }
+      invariant($all_levels->contains($level_id) !== false, 'level not found');
+      $level = $all_levels->get($level_id);
+      invariant($level instanceof Level, 'level should be of type Level');
+      return $level;
     } else {
       invariant(
         $mc_result instanceof Map,
         'cache return should be of type Map',
       );
       invariant($mc_result->contains($level_id) !== false, 'level not found');
-      if ($mc_result->contains($level_id)) {
-        $level = $mc_result->get($level_id);
-        invariant($level instanceof Level, 'level should be of type Level');
-        return $level;
-      }
+      $level = $mc_result->get($level_id);
+      invariant($level instanceof Level, 'level should be of type Level');
+      return $level;
     }
   }
 

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -69,6 +69,7 @@ class ScoreLog extends Model {
     $db = await self::genDb();
     await $db->queryf('DELETE FROM scores_log WHERE id > 0');
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.
@@ -217,6 +218,7 @@ class ScoreLog extends Model {
       $type,
     );
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -151,18 +151,9 @@ class ScoreLog extends Model {
         );
         $team_id_key = $level_capture_teams->linearSearch($team_id);
         if ($team_id_key != -1) {
-          $level_capture_teams = $level_captures->get($level_id);
-          invariant(
-            $level_capture_teams !== null,
-            'level_capture_teams should not be null',
-          );
           $level_capture_teams->removeKey($team_id_key);
         }
-        invariant(
-          $level_captures !== null,
-          'level_captures should not be null',
-        );
-        return intval(count($level_captures->get($level_id))) > 0;
+        return intval(count($level_capture_teams)) > 0;
       } else {
         $level_capture_teams = $level_captures->get($level_id);
         invariant(

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -92,12 +92,12 @@ class ScoreLog extends Model {
       foreach ($result->mapRows() as $row) {
         if ($level_captures->contains(intval($row->get('level_id')))) {
           $level_capture_teams =
-            $level_captures->get(intval($row->get('level_id')));
+            $level_captures->get(intval($row->get("level_id")));
           invariant(
-            $level_capture_teams instanceof Vector,
-            'level_capture_teams should of type Vector and not null',
+            $level_capture_teams !== null,
+            'level_captures should not be null',
           );
-          $level_capture_teams->add(intval($row->get('team_id')));
+          $level_capture_teams->add(intval($row->get("team_id")));
           $level_captures->set(
             intval($row->get('level_id')),
             $level_capture_teams,
@@ -136,30 +136,41 @@ class ScoreLog extends Model {
         return false;
       }
     }
+    $level_captures = self::getMCRecords('LEVEL_CAPTURES');
+    invariant($level_captures !== null, 'level_captures should not be null');
     invariant(
-      $mc_result instanceof Map,
-      'cache return should of type Map and not null',
+      $level_captures instanceof Map,
+      'level_captures should be of type Map',
     );
-    if ($mc_result->contains($level_id)) {
+    if ($level_captures->contains($level_id)) {
       if ($any_team) {
-        $level_capture_teams = $mc_result->get($level_id);
+        $level_capture_teams = $level_captures->get($level_id);
         invariant(
-          $level_capture_teams instanceof Vector,
-          'level_capture_teams should of type Vector and not null',
+          $level_capture_teams !== null,
+          'level_capture_teams should not be null',
         );
         $team_id_key = $level_capture_teams->linearSearch($team_id);
-        if ($team_id_key !== -1) {
+        if ($team_id_key != -1) {
+          $level_capture_teams = $level_captures->get($level_id);
+          invariant(
+            $level_capture_teams !== null,
+            'level_capture_teams should not be null',
+          );
           $level_capture_teams->removeKey($team_id_key);
         }
-        return intval(count($level_capture_teams)) > 0;
-      } else {
-        $level_capture_teams = $mc_result->get($level_id);
         invariant(
-          $level_capture_teams instanceof Vector,
-          'level_capture_teams should of type Vector and not null',
+          $level_captures !== null,
+          'level_captures should not be null',
+        );
+        return intval(count($level_captures->get($level_id))) > 0;
+      } else {
+        $level_capture_teams = $level_captures->get($level_id);
+        invariant(
+          $level_capture_teams !== null,
+          'level_capture_teams should not be null',
         );
         $team_id_key = $level_capture_teams->linearSearch($team_id);
-        return $team_id_key !== -1;
+        return $team_id_key != -1;
       }
     } else {
       return false;

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -69,7 +69,7 @@ class ScoreLog extends Model {
     $db = await self::genDb();
     await $db->queryf('DELETE FROM scores_log WHERE id > 0');
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
-    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.
@@ -92,12 +92,12 @@ class ScoreLog extends Model {
       foreach ($result->mapRows() as $row) {
         if ($level_captures->contains(intval($row->get('level_id')))) {
           $level_capture_teams =
-            $level_captures->get(intval($row->get("level_id")));
+            $level_captures->get(intval($row->get('level_id')));
           invariant(
             $level_capture_teams !== null,
             'level_captures should not be null',
           );
-          $level_capture_teams->add(intval($row->get("team_id")));
+          $level_capture_teams->add(intval($row->get('team_id')));
           $level_captures->set(
             intval($row->get('level_id')),
             $level_capture_teams,
@@ -229,7 +229,7 @@ class ScoreLog extends Model {
       $type,
     );
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
-    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -69,6 +69,7 @@ class ScoreLog extends Model {
     $db = await self::genDb();
     await $db->queryf('DELETE FROM scores_log WHERE id > 0');
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
+    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.
@@ -217,6 +218,7 @@ class ScoreLog extends Model {
       $type,
     );
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
+    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -314,6 +314,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
+    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
   }
 
   // Update team password.
@@ -338,6 +339,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
+    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
   }
 
   // Enable or disable teams by passing 1 or 0.
@@ -390,6 +392,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
+    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
   }
 
   // Check if a team name is already created.

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -314,7 +314,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
-    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
   }
 
   // Update team password.
@@ -339,7 +339,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
-    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
   }
 
   // Enable or disable teams by passing 1 or 0.
@@ -392,7 +392,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
-    Control::invalidateMCRecords("ALL_ACTIVITY"); // Invalidate Memcached Control data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
   }
 
   // Check if a team name is already created.


### PR DESCRIPTION
* Updated Memcached Implementation on Country, ScoreLog, and Team.

* Updated Level::genWhoUses(), Level::genCheckStatus(), Level::genCheckBase() to reduce queries and utilize Memcached.  Previously each method was calling one query per country.  Now the methods have been updated to consolidate the various queries into a single query for all levels.  The resulting data is stored in Memcached and queries only runs after cache invalidation.

* Updated Level::genAllLevels(), Level::genAllActiveLevels(), and Level::genAllActiveBases() to utilize Memcached.  These methods were previously only calling a single query each, but they are used often on the Gameboard updates.

* Updated Level::genAllTypeLevels() to utilize Memcached.  This method was previously performing a single query per level type, but the method is used frequently on the Gameboard updates.

* Updated Level::gen() to utilize Memcached.  This method is used to generate a single level, and was called 1(n) times per level.  Now all levels are stored in Memcached and retrieved as needed.

* The Memcached data for Level is invalidated on demand.  This invalidation takes place when Levels are updated, added, or removed.

* Updated the Memcached implementation within the Country class to bring it inline with the other Memcached code.

* Updated the Control class to implement Memcached on Control::genAllActivity().  This method is utilized to generate the Activity log used on the Gameboard.  The method previously executed a single query frequently on Gameboard updates.  Now the query is executed once, with the results stored in Memcached.  The cache is invalidated on any Scoring event or modification to the relevant dependencies, such as changes to Levels, Countries, Teams, etc.

* Updated the ScoreLog class to invalidate Control and MultiTeam caches when scores are reset or a scoring event is triggered.

* Updated ScoreLog::genPreviousScore() to move the database connection inside of the condition block in which it is utilized.  This eliminates the database connection when no query will take place.

* Updated the Team class to invalidate the Activity log cache when a team is updated, deleted, or the visibility is changed.

* Removed caching from Country::genAll() as the relevant caches have been moved to the appropriate methods within the class.

* The Memcached data for Country is invalidated on demand.  This invalidation takes place when countries are updated, such as a change in status or usage.