### PR TITLE
Added Memcached Implementation to HintLog

### DIFF
--- a/src/controllers/ajax/GameAjaxController.php
+++ b/src/controllers/ajax/GameAjaxController.php
@@ -60,13 +60,6 @@ class GameAjaxController extends AjaxController {
             );
             // Update teams last score
             await Team::genLastScore(SessionUtils::sessionTeam());
-            // Invalidate score cache
-            MultiTeam::invalidateMCRecords('ALL_TEAMS');
-            MultiTeam::invalidateMCRecords('POINTS_BY_TYPE');
-            MultiTeam::invalidateMCRecords('LEADERBOARD');
-            MultiTeam::invalidateMCRecords('TEAMS_BY_LEVEL');
-            MultiTeam::invalidateMCRecords('TEAMS_FIRST_CAP');
-            ScoreLog::invalidateMCRecords('LEVEL_CAPTURES');
             return Utils::ok_response('Success', 'game');
           } else {
             await FailureLog::genLogFailedScore(
@@ -85,6 +78,9 @@ class GameAjaxController extends AjaxController {
           SessionUtils::sessionTeam(),
         );
         if ($requested_hint !== null) {
+          MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
+          MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
+          MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.
           return Utils::hint_response($requested_hint, 'OK');
         } else {
           return Utils::hint_response('', 'ERROR');

--- a/src/models/HintLog.php
+++ b/src/models/HintLog.php
@@ -5,7 +5,7 @@ class HintLog extends Model {
   protected static string $MC_KEY = 'hintlog:';
 
   protected static Map<string, string>
-    $MC_KEYS = Map {"USED_HINTS" => "hint_level_teams"};
+    $MC_KEYS = Map {'USED_HINTS' => 'hint_level_teams'};
 
   private function __construct(
     private int $id,
@@ -79,36 +79,47 @@ class HintLog extends Model {
       $hints_used = Map {};
       $result = await $db->queryf('SELECT level_id, team_id FROM hints_log');
       foreach ($result->mapRows() as $row) {
-        if ($hints_used->contains(intval($row->get("level_id")))) {
-          $hints_used_teams = $hints_used->get(intval($row->get("level_id")));
-          /* HH_IGNORE_ERROR[4064] */
-          $hints_used_teams->add(intval($row->get("team_id")));
-          $hints_used->set(intval($row->get("level_id")), $hints_used_teams);
+        if ($hints_used->contains(intval($row->get('level_id')))) {
+          $hints_used_teams = $hints_used->get(intval($row->get('level_id')));
+          invariant(
+            $hints_used_teams !== null,
+            'hints_used_teams should not be null',
+          );
+          $hints_used_teams->add(intval($row->get('team_id')));
+          $hints_used->set(intval($row->get('level_id')), $hints_used_teams);
         } else {
           $hints_used_teams = Vector {};
-          $hints_used_teams->add(intval($row->get("team_id")));
+          $hints_used_teams->add(intval($row->get('team_id')));
           $hints_used->add(
-            Pair {intval($row->get("level_id")), $hints_used_teams},
+            Pair {intval($row->get('level_id')), $hints_used_teams},
           );
         }
       }
       self::setMCRecords('USED_HINTS', new Map($hints_used));
     }
     $hints_used = self::getMCRecords('USED_HINTS');
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant($hints_used !== null, 'hints_used should not be null');
+    invariant($hints_used instanceof Map, 'hints_used should be of type Map');
     if ($hints_used->contains($level_id)) {
       if ($any_team) {
-        $team_id_key = /* HH_IGNORE_ERROR[4062] */
-          $hints_used->get($level_id)->linearSearch($team_id);
+        $hints_used_teams = $hints_used->get($level_id);
+        invariant(
+          $hints_used_teams !== null,
+          'hints_used_teams should not be null',
+        );
+        $team_id_key = $hints_used_teams->linearSearch($team_id);
         if ($team_id_key != -1) {
-          /* HH_IGNORE_ERROR[4062] */
-          $hints_used->get($level_id)->removeKey($team_id_key);
+          $hints_used_teams->removeKey($team_id_key);
         }
-        /* HH_IGNORE_ERROR[4062] */
-        return intval(count($hints_used->get($level_id))) > 0;
+        return intval(count($hints_used_teams)) > 0;
       } else {
-        /* HH_IGNORE_ERROR[4062] */
-        return $hints_used->get($level_id)->linearSearch($team_id) != -1;
+        $hints_used_teams = $hints_used->get($level_id);
+        invariant(
+          $hints_used_teams !== null,
+          'hints_used_teams should not be null',
+        );
+        $team_id_key = $hints_used_teams->linearSearch($team_id);
+        return $team_id_key != -1;
       }
     } else {
       return false;

--- a/src/models/HintLog.php
+++ b/src/models/HintLog.php
@@ -96,33 +96,59 @@ class HintLog extends Model {
         }
       }
       self::setMCRecords('USED_HINTS', new Map($hints_used));
-    }
-    $hints_used = self::getMCRecords('USED_HINTS');
-    invariant($hints_used !== null, 'hints_used should not be null');
-    invariant($hints_used instanceof Map, 'hints_used should be of type Map');
-    if ($hints_used->contains($level_id)) {
-      if ($any_team) {
-        $hints_used_teams = $hints_used->get($level_id);
-        invariant(
-          $hints_used_teams !== null,
-          'hints_used_teams should not be null',
-        );
-        $team_id_key = $hints_used_teams->linearSearch($team_id);
-        if ($team_id_key != -1) {
-          $hints_used_teams->removeKey($team_id_key);
+      if ($hints_used->contains($level_id)) {
+        if ($any_team) {
+          $hints_used_teams = $hints_used->get($level_id);
+          invariant(
+            $hints_used_teams !== null,
+            'hints_used_teams should not be null',
+          );
+          $team_id_key = $hints_used_teams->linearSearch($team_id);
+          if ($team_id_key !== -1) {
+            $hints_used_teams->removeKey($team_id_key);
+          }
+          return intval(count($hints_used_teams)) > 0;
+        } else {
+          $hints_used_teams = $hints_used->get($level_id);
+          invariant(
+            $hints_used_teams !== null,
+            'hints_used_teams should not be null',
+          );
+          $team_id_key = $hints_used_teams->linearSearch($team_id);
+          return $team_id_key !== -1;
         }
-        return intval(count($hints_used_teams)) > 0;
       } else {
-        $hints_used_teams = $hints_used->get($level_id);
-        invariant(
-          $hints_used_teams !== null,
-          'hints_used_teams should not be null',
-        );
-        $team_id_key = $hints_used_teams->linearSearch($team_id);
-        return $team_id_key != -1;
+        return false;
       }
     } else {
-      return false;
+      invariant(
+        $mc_result instanceof Map,
+        'hints_used should be of type Map',
+      );
+      if ($mc_result->contains($level_id)) {
+        if ($any_team) {
+          $hints_used_teams = $mc_result->get($level_id);
+          invariant(
+            $hints_used_teams !== null,
+            'hints_used_teams should not be null',
+          );
+          $team_id_key = $hints_used_teams->linearSearch($team_id);
+          if ($team_id_key !== -1) {
+            $hints_used_teams->removeKey($team_id_key);
+          }
+          return intval(count($hints_used_teams)) > 0;
+        } else {
+          $hints_used_teams = $mc_result->get($level_id);
+          invariant(
+            $hints_used_teams !== null,
+            'hints_used_teams should not be null',
+          );
+          $team_id_key = $hints_used_teams->linearSearch($team_id);
+          return $team_id_key !== -1;
+        }
+      } else {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
* Updated HintLog::genPreviousHint() to utilize Memcached.  Previously the method was calling 2(n) queries per level.  Now the query has been consolidated to a single query, and the data is stored in Memcached.  The single query will now only run after invalidation due to a hint being used.

* Updated the GameAjaxController class to invalidate the caches for scoring (the MultiTeam class) on hint usage.

* Updated GameAjaxController class to remove the MultiTeam and ScoreLog cache invalidations on a valid scoring event, these are now handled internally within the relevant classes.  This change is dependent on PR: facebook/fbctf#339