### PR TITLE
Added Memcached Implementation to Progressive

### DIFF
--- a/src/models/Progressive.php
+++ b/src/models/Progressive.php
@@ -6,8 +6,8 @@ class Progressive extends Model {
 
   protected static Map<string, string>
     $MC_KEYS = Map {
-      "ITERATION_COUNT" => "iterations_count",
-      "PROGRESSIVE_POINTS" => "points_by_teamname",
+      'ITERATION_COUNT' => 'iterations_count',
+      'PROGRESSIVE_POINTS' => 'points_by_teamname',
     };
 
   private function __construct(
@@ -74,7 +74,7 @@ class Progressive extends Model {
           'SELECT * FROM progressive_log GROUP BY team_name, iteration ORDER BY points ASC',
         );
       foreach ($result->mapRows() as $row) {
-        $progressive[$row->get("team_name")][] =
+        $progressive[$row->get('team_name')][] =
           self::progressiveFromRow($row);
       }
       self::setMCRecords('PROGRESSIVE_POINTS', new Map($progressive));
@@ -82,14 +82,21 @@ class Progressive extends Model {
 
     $progressive = self::getMCRecords('PROGRESSIVE_POINTS');
     /* HH_IGNORE_ERROR[4062] */
+    invariant($progressive !== null, 'progressive should not be null');
+    invariant(
+      $progressive instanceof Map,
+      'progressive should be of type Map',
+    );
     if ($progressive->contains($team_name)) {
-      /* HH_IGNORE_ERROR[4062] */
-      return $progressive->get($team_name);
+      $team_progressive = $progressive->get($team_name);
+      invariant(
+        $team_progressive !== null,
+        'team_progressive should not be null',
+      );
+      return $team_progressive;
     } else {
       return array();
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('PROGRESSIVE_POINTS');
   }
 
   // Count how many iterations of the progressive scoreboard we have.
@@ -109,7 +116,9 @@ class Progressive extends Model {
       );
     }
     /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
-    return self::getMCRecords('ITERATION_COUNT');
+    $iteration_count = intval(self::getMCRecords('ITERATION_COUNT'));
+    invariant($iteration_count !== null, 'progressive should not be null');
+    return $iteration_count;
   }
 
   // Acquire the data for one iteration of the progressive scoreboard.

--- a/src/models/Progressive.php
+++ b/src/models/Progressive.php
@@ -78,23 +78,32 @@ class Progressive extends Model {
           self::progressiveFromRow($row);
       }
       self::setMCRecords('PROGRESSIVE_POINTS', new Map($progressive));
-    }
-
-    $progressive = self::getMCRecords('PROGRESSIVE_POINTS');
-    invariant($progressive !== null, 'progressive should not be null');
-    invariant(
-      $progressive instanceof Map,
-      'progressive should be of type Map',
-    );
-    if ($progressive->contains($team_name)) {
-      $team_progressive = $progressive->get($team_name);
-      invariant(
-        $team_progressive !== null,
-        'team_progressive should not be null',
-      );
-      return $team_progressive;
+      $progressive = new Map($progressive);
+      if ($progressive->contains($team_name)) {
+        $team_progressive = $progressive->get($team_name);
+        invariant(
+          is_array($team_progressive),
+          'team_progressive should not an array of Progressive',
+        );
+        return $team_progressive;
+      } else {
+        return array();
+      }
     } else {
-      return array();
+      invariant(
+        $mc_result instanceof Map,
+        'cache return should be of type Map',
+      );
+      if ($mc_result->contains($team_name)) {
+        $team_progressive = $mc_result->get($team_name);
+        invariant(
+          is_array($team_progressive),
+          'team_progressive should not an array of Progressive',
+        );
+        return $team_progressive;
+      } else {
+        return array();
+      }
     }
   }
 
@@ -113,10 +122,10 @@ class Progressive extends Model {
         'ITERATION_COUNT',
         intval($result->mapRows()[0]['C']),
       );
+      return intval($result->mapRows()[0]['C']);
+    } else {
+      return intval($mc_result);
     }
-    $iteration_count = intval(self::getMCRecords('ITERATION_COUNT'));
-    invariant($iteration_count !== null, 'progressive should not be null');
-    return $iteration_count;
   }
 
   // Acquire the data for one iteration of the progressive scoreboard.

--- a/src/models/Progressive.php
+++ b/src/models/Progressive.php
@@ -81,7 +81,6 @@ class Progressive extends Model {
     }
 
     $progressive = self::getMCRecords('PROGRESSIVE_POINTS');
-    /* HH_IGNORE_ERROR[4062] */
     invariant($progressive !== null, 'progressive should not be null');
     invariant(
       $progressive instanceof Map,
@@ -115,7 +114,6 @@ class Progressive extends Model {
         intval($result->mapRows()[0]['C']),
       );
     }
-    /* HH_IGNORE_ERROR[4110]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
     $iteration_count = intval(self::getMCRecords('ITERATION_COUNT'));
     invariant($iteration_count !== null, 'progressive should not be null');
     return $iteration_count;


### PR DESCRIPTION
* Updated Progressive::genProgressiveGameboard() to utilize Memcached.  Previously the method was calling 1(n) query per team.  Now the queries have been consolidated to a single query, and the data is stored in Memcached.  The queries will now only run after invalidation due to a change to the progressive log.

* Updated Progressive::genCount() to store the results in Memcached.  The cache is updated when the iteration changes, based on an update to the progressive log.

* The restructuring of this code has the benefit of fixing the graphic score display on the Scoreboard.