### PR TITLE
Added Memcached Implementation to Link

### DIFF
--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -80,24 +80,34 @@ class Link extends Model {
         $links[$row->get('level_id')][] = self::linkFromRow($row);
       }
       self::setMCRecords('LEVEL_LINKS', new Map($links));
-    }
-    $links = self::getMCRecords('LEVEL_LINKS');
-    invariant($links !== null, 'links should not be null');
-    invariant($links instanceof Map, 'links should be of type Map');
-    if ($links->contains($level_id)) {
-      $link_array = $links->get($level_id);
-      invariant(
-        is_array($link_array),
-        '$link_array should be an array of Link',
-      );
-      return $link_array;
+      $links = new Map($links);
+      if ($links->contains($level_id)) {
+        $link_array = $links->get($level_id);
+        invariant(
+          is_array($link_array),
+          '$link_array should be an array of Link',
+        );
+        return $link_array;
+      } else {
+        return array();
+      }
     } else {
-      return array();
+      invariant($mc_result instanceof Map, 'links should be of type Map');
+      if ($mc_result->contains($level_id)) {
+        $link_array = $mc_result->get($level_id);
+        invariant(
+          is_array($link_array),
+          '$link_array should be an array of Link',
+        );
+        return $link_array;
+      } else {
+        return array();
+      }
     }
   }
 
   // Get a single link.
-  /* HH_IGNORE_ERROR[4110]: HHVM is concerned that the link might not be present, this is verified by the caller */
+  /* HH_IGNORE_ERROR[4110]: Lines #827 and #835 prevent this function from failing to return */
   public static async function gen(
     int $link_id,
     bool $refresh = false,
@@ -111,14 +121,20 @@ class Link extends Model {
         $links->add(Pair {intval($row->get('id')), self::linkFromRow($row)});
       }
       self::setMCRecords('LINKS', $links);
-    }
-    $links = self::getMCRecords('LINKS');
-    invariant($links !== null, 'links should not be null');
-    invariant($links instanceof Map, 'links should be of type Map');
-    if ($links->contains($link_id)) {
-      $link = $links->get($link_id);
-      invariant($link instanceof Link, 'link should be of type Link');
-      return $link;
+      invariant($links->contains($link_id) !== false, 'link not found');
+      if ($links->contains($link_id)) {
+        $link = $links->get($link_id);
+        invariant($link instanceof Link, 'link should be of type Link');
+        return $link;
+      }
+    } else {
+      invariant($mc_result instanceof Map, 'links should be of type Map');
+      invariant($mc_result->contains($link_id) !== false, 'link not found');
+      if ($mc_result->contains($link_id)) {
+        $link = $mc_result->get($link_id);
+        invariant($link instanceof Link, 'link should be of type Link');
+        return $link;
+      }
     }
   }
 
@@ -141,15 +157,23 @@ class Link extends Model {
         );
       }
       self::setMCRecords('LEVELS_COUNT', $link_count);
-    }
-    $link_count = self::getMCRecords('LEVELS_COUNT');
-    invariant($link_count !== null, 'link_count should not be null');
-    invariant($link_count instanceof Map, 'link_count should be of type Map');
-    if ($link_count->contains($level_id)) {
-      $level_link_count = $link_count->get($level_id);
-      return intval($level_link_count) > 0;
+      if ($link_count->contains($level_id)) {
+        $level_link_count = $link_count->get($level_id);
+        return intval($level_link_count) > 0;
+      } else {
+        return false;
+      }
     } else {
-      return false;
+      invariant(
+        $mc_result instanceof Map,
+        'link_count should be of type Map',
+      );
+      if ($mc_result->contains($level_id)) {
+        $level_link_count = $mc_result->get($level_id);
+        return intval($level_link_count) > 0;
+      } else {
+        return false;
+      }
     }
   }
 

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -6,9 +6,9 @@ class Link extends Model {
 
   protected static Map<string, string>
     $MC_KEYS = Map {
-      "LEVELS_COUNT" => "link_levels_count",
-      "LEVEL_LINKS" => "link_levels",
-      "LINKS" => "link_by_id",
+      'LEVELS_COUNT' => 'link_levels_count',
+      'LEVEL_LINKS' => 'link_levels',
+      'LINKS' => 'link_by_id',
     };
 
   private function __construct(
@@ -77,15 +77,20 @@ class Link extends Model {
       $links = array();
       $result = await $db->queryf('SELECT * FROM links');
       foreach ($result->mapRows() as $row) {
-        $links[$row->get("level_id")][] = self::linkFromRow($row);
+        $links[$row->get('level_id')][] = self::linkFromRow($row);
       }
       self::setMCRecords('LEVEL_LINKS', new Map($links));
     }
     $links = self::getMCRecords('LEVEL_LINKS');
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant($links !== null, 'links should not be null');
+    invariant($links instanceof Map, 'links should be of type Map');
     if ($links->contains($level_id)) {
-      /* HH_IGNORE_ERROR[4062] */
-      return $links->get($level_id);
+      $link_array = $links->get($level_id);
+      invariant(
+        is_array($link_array),
+        '$link_array should be an array of Link',
+      );
+      return $link_array;
     } else {
       return array();
     }
@@ -103,21 +108,17 @@ class Link extends Model {
       $links = Map {};
       $result = await $db->queryf('SELECT * FROM links');
       foreach ($result->mapRows() as $row) {
-        $links->add(Pair {intval($row->get("id")), self::linkFromRow($row)});
+        $links->add(Pair {intval($row->get('id')), self::linkFromRow($row)});
       }
       self::setMCRecords('LINKS', $links);
     }
     $links = self::getMCRecords('LINKS');
-
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant($links !== null, 'links should not be null');
+    invariant($links instanceof Map, 'links should be of type Map');
     if ($links->contains($link_id)) {
-      /* HH_IGNORE_ERROR[4062] */
-      return $links->get($link_id);
-    } else {
-      invariant(
-        /* HH_IGNORE_ERROR[4062] */ $links->contains($link_id),
-        'Link doesn\'t exist in cache',
-      );
+      $link = $links->get($link_id);
+      invariant($link instanceof Link, 'link should be of type Link');
+      return $link;
     }
   }
 
@@ -136,17 +137,17 @@ class Link extends Model {
         );
       foreach ($result->mapRows() as $row) {
         $link_count->add(
-          Pair {intval($row->get("level_id")), intval($row->get("count"))},
+          Pair {intval($row->get('level_id')), intval($row->get('count'))},
         );
       }
       self::setMCRecords('LEVELS_COUNT', $link_count);
     }
     $link_count = self::getMCRecords('LEVELS_COUNT');
-
-    /* HH_IGNORE_ERROR[4062]: getMCRecords returns a 'mixed' type, HHVM is unsure of the type at this point */
+    invariant($link_count !== null, 'link_count should not be null');
+    invariant($link_count instanceof Map, 'link_count should be of type Map');
     if ($link_count->contains($level_id)) {
-      /* HH_IGNORE_ERROR[4062]: */
-      return intval($link_count->get($level_id)) > 0;
+      $level_link_count = $link_count->get($level_id);
+      return intval($level_link_count) > 0;
     } else {
       return false;
     }

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -107,7 +107,6 @@ class Link extends Model {
   }
 
   // Get a single link.
-  /* HH_IGNORE_ERROR[4110]: Lines #827 and #835 prevent this function from failing to return */
   public static async function gen(
     int $link_id,
     bool $refresh = false,
@@ -122,19 +121,15 @@ class Link extends Model {
       }
       self::setMCRecords('LINKS', $links);
       invariant($links->contains($link_id) !== false, 'link not found');
-      if ($links->contains($link_id)) {
-        $link = $links->get($link_id);
-        invariant($link instanceof Link, 'link should be of type Link');
-        return $link;
-      }
+      $link = $links->get($link_id);
+      invariant($link instanceof Link, 'link should be of type Link');
+      return $link;
     } else {
       invariant($mc_result instanceof Map, 'links should be of type Map');
       invariant($mc_result->contains($link_id) !== false, 'link not found');
-      if ($mc_result->contains($link_id)) {
-        $link = $mc_result->get($link_id);
-        invariant($link instanceof Link, 'link should be of type Link');
-        return $link;
-      }
+      $link = $mc_result->get($link_id);
+      invariant($link instanceof Link, 'link should be of type Link');
+      return $link;
     }
   }
 


### PR DESCRIPTION
* Updated Link::genAllLinks() to utilize Memcached.  Previously the method was calling 1(n) query per level.  Now the queries have been consolidated to a single query, and the data is stored in Memcached.  The queries will now only run after invalidation due to a link being altered.