### PR TITLE
Added Memcached Implementation to Sessions

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -13,7 +13,7 @@ class Router {
     if ($ajax) {
       return await self::genRouteAjax($page);
     } else if ($modal !== null) {
-      $xhp = await self::genRouteModel($page, strval($modal));
+      $xhp = await self::genRouteModal($page, strval($modal));
       return strval($xhp);
     } else {
       $response = await self::genRouteNormal($page);
@@ -21,7 +21,7 @@ class Router {
     }
   }
 
-  private static async function genRouteModel(
+  private static async function genRouteModal(
     string $page,
     string $modal,
   ): Awaitable<:xhp> {

--- a/src/Router.php
+++ b/src/Router.php
@@ -25,6 +25,7 @@ class Router {
     string $page,
     string $modal,
   ): Awaitable<:xhp> {
+    SessionUtils::sessionStart();
     switch ($page) {
       case 'action':
         return await (new ActionModalController())->genRender($modal);
@@ -96,6 +97,10 @@ class Router {
 
   public static function isRequestAjax(): bool {
     return Utils::getGET()->get('ajax') === 'true';
+  }
+
+  public static function isRequestModal(): bool {
+    return Utils::getGET()->get('modal') !== null;
   }
 
   // Check to see if the request is going through the router

--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -411,6 +411,7 @@ class Session extends Model {
 
   private static function setMCSession(string $key, mixed $records): void {
     $mc = self::getMc();
+    $key = str_replace(' ', '', $key);
     $mc->set(
       self::$MC_KEY.self::$MC_KEYS->get("SESSIONS").$key,
       $records,
@@ -420,6 +421,7 @@ class Session extends Model {
 
   private static function getMCSession(string $key): mixed {
     $mc = self::getMc();
+    $key = str_replace(' ', '', $key);
     $mc_result =
       $mc->get(static::$MC_KEY.static::$MC_KEYS->get("SESSIONS").$key);
     return $mc_result;
@@ -427,6 +429,7 @@ class Session extends Model {
 
   public static function invalidateMCSessions(?string $key = null): void {
     $mc = self::getMc();
+    $key = str_replace(' ', '', $key);
     /* HH_IGNORE_ERROR[4053]: HHVM doesn't beleive there is a getAllKeys() method, there is... */
     $mc_keys = $mc->getAllKeys();
     if ($key === null) {

--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -1,6 +1,12 @@
 <?hh // strict
 
 class Session extends Model {
+
+  protected static string $MC_KEY = 'sessions:';
+
+  protected static Map<string, string>
+    $MC_KEYS = Map {"SESSIONS" => "active_sessions:"};
+
   private function __construct(
     private int $id,
     private string $cookie,
@@ -52,7 +58,10 @@ class Session extends Model {
     string $cookie,
     string $data,
   ): Awaitable<void> {
-    if (Router::isRequestAjax() || !Router::isRequestRouter()) {
+    await self::genSetTeamIdCacheSession($cookie, $data);
+    if (Router::isRequestModal() ||
+        Router::isRequestAjax() ||
+        !Router::isRequestRouter()) {
       return;
     }
     $team_id = self::decodeTeamId($data);
@@ -62,6 +71,22 @@ class Session extends Model {
       $team_id,
       $cookie,
     );
+  }
+
+  public static async function genSetTeamIdCacheSession(
+    string $cookie,
+    string $data,
+  ): Awaitable<void> {
+    $sessions = Map {};
+    $session_data = Map {};
+    $mc_result = self::getMCSession($cookie);
+    if ($mc_result) {
+      /* HH_IGNORE_ERROR[4062]: getMCSession returns a 'mixed' type, HHVM is unsure of the type at this point */
+      $mc_result->team_id = self::decodeTeamId($data);
+      self::setMCSession($cookie, $mc_result);
+    } else {
+      await self::genCreateCacheSession($cookie);
+    }
   }
 
   private static function sessionFromRow(Map<string, string> $row): Session {
@@ -88,46 +113,81 @@ class Session extends Model {
       $data,
       Router::getRequestedPage(),
     );
+    if ($data !== "") {
+      await self::genCreateCacheSession($cookie);
+    }
+  }
+
+  // Create new session.
+  public static async function genCreateCacheSession(
+    string $cookie,
+  ): Awaitable<void> {
+    $session_data = await self::gen($cookie, true);
+    self::setMCSession($cookie, $session_data);
   }
 
   // Retrieve the session by cookie.
-  public static async function gen(string $cookie): Awaitable<Session> {
-    $db = await self::genDb();
-    $result = await $db->queryf(
-      'SELECT * FROM sessions WHERE cookie = %s LIMIT 1',
-      $cookie,
-    );
+  public static async function gen(
+    string $cookie,
+    bool $refresh = false,
+  ): Awaitable<Session> {
+    $mc_result = self::getMCSession($cookie);
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $db = await self::genDb();
+      $result = await $db->queryf(
+        'SELECT * FROM sessions WHERE cookie = %s LIMIT 1',
+        $cookie,
+      );
 
-    invariant($result->numRows() === 1, 'Expected exactly one result');
-
-    return self::sessionFromRow($result->mapRows()[0]);
+      invariant($result->numRows() === 1, 'Expected exactly one result');
+      $session_data = self::sessionFromRow($result->mapRows()[0]);
+      self::setMCSession($cookie, $session_data);
+    }
+    /* HH_IGNORE_ERROR[4110]: getMCSession returns a 'mixed' type, HHVM is unsure of the type at this point */
+    return self::getMCSession($cookie);
   }
 
   // Checks if session exists by cookie.
   public static async function genSessionExist(
     string $cookie,
+    bool $refresh = false,
   ): Awaitable<bool> {
-    $db = await self::genDb();
-    $result = await $db->queryf(
-      'SELECT COUNT(*) FROM sessions WHERE cookie = %s',
-      $cookie,
-    );
-    invariant($result->numRows() === 1, 'Expected exactly one result');
-
-    return intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0;
+    $mc_result = self::getMCSession($cookie);
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $db = await self::genDb();
+      $result = await $db->queryf(
+        'SELECT COUNT(*) FROM sessions WHERE cookie = %s',
+        $cookie,
+      );
+      invariant($result->numRows() === 1, 'Expected exactly one result');
+      if (intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0) {
+        await self::genCreateCacheSession($cookie);
+      }
+    }
+    return self::getMCSession($cookie) != false;
   }
 
   public static async function genSessionDataIfExist(
     string $cookie,
+    bool $refresh = false,
   ): Awaitable<string> {
-    $db = await self::genDb();
-    $result = await $db->queryf(
-      'SELECT * FROM sessions WHERE cookie = %s LIMIT 1',
-      $cookie,
-    );
+    $mc_result = self::getMCSession($cookie);
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $db = await self::genDb();
+      $result = await $db->queryf(
+        'SELECT * FROM sessions WHERE cookie = %s LIMIT 1',
+        $cookie,
+      );
 
-    if ($result->numRows() === 1) {
-      $session = self::sessionFromRow($result->mapRows()[0]);
+      if ($result->numRows() === 1) {
+        await self::genCreateCacheSession($cookie);
+      } else {
+        return '';
+      }
+    }
+    $session = self::getMCSession($cookie);
+    if ($session) {
+      /* HH_IGNORE_ERROR[4062]: getMCSession returns a 'mixed' type, HHVM is unsure of the type at this point */
       return $session->getData();
     } else {
       return '';
@@ -138,8 +198,13 @@ class Session extends Model {
   public static async function genUpdate(
     string $cookie,
     string $data,
+    bool $refresh = false,
   ): Awaitable<void> {
-    if (Router::isRequestAjax() || !Router::isRequestRouter()) {
+    await self::genUpdateCacheSession($cookie, $data);
+    if (!$refresh &&
+        (Router::isRequestModal() ||
+         Router::isRequestAjax() ||
+         !Router::isRequestRouter())) {
       return;
     }
     $db = await self::genDb();
@@ -151,6 +216,33 @@ class Session extends Model {
     );
   }
 
+  // Update the cache version of a session for a given cookie.
+  public static async function genUpdateCacheSession(
+    string $cookie,
+    string $data,
+  ): Awaitable<void> {
+    if ($data === "") {
+      return;
+    }
+    $mc_result = self::getMCSession($cookie);
+    if ($mc_result) {
+      /* HH_IGNORE_ERROR[4062]: getMCSession returns a 'mixed' type, HHVM is unsure of the type at this point */
+      $mc_result->last_access_ts = date("Y-m-d H:i:s");
+      /* HH_IGNORE_ERROR[4062] */
+      $mc_result->data = $data;
+      /* HH_IGNORE_ERROR[4062] */
+      $last_page_access = Router::getRequestedPage();
+      if ($last_page_access !== "index") {
+        /* HH_IGNORE_ERROR[4062] */
+        $mc_result->last_page_access = $last_page_access;
+      }
+      self::setMCSession($cookie, $mc_result);
+    } else {
+      await self::genCreateCacheSession($cookie);
+    }
+    $sess = self::getMCSession($cookie);
+  }
+
   // Delete the session for a given cookie.
   public static async function genDelete(string $cookie): Awaitable<void> {
     $db = await self::genDb();
@@ -158,23 +250,73 @@ class Session extends Model {
       'DELETE FROM sessions WHERE cookie = %s LIMIT 1',
       $cookie,
     );
+    self::invalidateMCSessions($cookie);
   }
 
   // Delete the session for a given a team id.
   public static async function genDeleteByTeam(int $team_id): Awaitable<void> {
     $db = await self::genDb();
+    $team_sessions = await self::genSessionsByTeam($team_id);
     await $db->queryf(
       'DELETE FROM sessions WHERE team_id = %d LIMIT 1',
       $team_id,
     );
+    foreach ($team_sessions as $session) {
+      self::invalidateMCSessions($session->getCookie());
+    }
+  }
+
+  public static async function genSessionsByTeam(
+    int $team_id,
+  ): Awaitable<array<Session>> {
+    $db = await self::genDb();
+    $result = await $db->queryf(
+      'SELECT * FROM sessions WHERE team_id = %d',
+      $team_id,
+    );
+
+    $sessions = array();
+    foreach ($result->mapRows() as $row) {
+      $sessions[] = self::sessionFromRow($row);
+    }
+
+    return $sessions;
   }
 
   // Does cleanup of cookies.
   public static async function genCleanup(int $maxlifetime): Awaitable<void> {
-    if (Router::isRequestAjax() || !Router::isRequestRouter()) {
+    if (Router::isRequestModal() ||
+        Router::isRequestAjax() ||
+        !Router::isRequestRouter()) {
       return;
     }
     $db = await self::genDb();
+    $expired_sessions =
+      await self::genExpiredSessionsForCleanup($maxlifetime);
+    $empty_sessions = await self::genEmptySessionsForCleanup();
+    foreach ($expired_sessions as $session) {
+      /* HH_IGNORE_ERROR[4062]: getMCSession returns a 'mixed' type, HHVM is unsure of the type at this point */
+      $cached_session = self::getMCSession($session->getCookie());
+      /* HH_IGNORE_ERROR[4062] */
+      $cached_timestamp = strtotime($cached_session->last_access_ts);
+      /* HH_IGNORE_ERROR[4062] */
+      if (strtotime($cached_session->last_access_ts) <
+          (time() - $maxlifetime)) {
+        self::invalidateMCSessions($session->getCookie());
+      } else {
+        await self::genUpdate(
+          $session->getCookie(),
+          $session->getData(),
+          true,
+        );
+      }
+    }
+    foreach ($empty_sessions as $session) {
+      $cached_session = self::getMCSession($session->getCookie());
+      if ($cached_session !== false && $cached_session === "") {
+        self::invalidateMCSessions($session->getCookie());
+      }
+    }
     // Clean up expired sessions
     await $db->queryf(
       'DELETE FROM sessions WHERE UNIX_TIMESTAMP(last_access_ts) < %d',
@@ -188,18 +330,115 @@ class Session extends Model {
     );
   }
 
-  // All the sessions
-  public static async function genAllSessions(): Awaitable<array<Session>> {
+  public static async function genExpiredSessionsForCleanup(
+    int $maxlifetime,
+  ): Awaitable<array<Session>> {
     $db = await self::genDb();
+    $sessions = array();
     $result = await $db->queryf(
-      'SELECT * FROM sessions ORDER BY last_access_ts DESC',
+      'SELECT * FROM sessions WHERE UNIX_TIMESTAMP(last_access_ts) < %d',
+      time() - $maxlifetime,
     );
 
-    $sessions = array();
     foreach ($result->mapRows() as $row) {
       $sessions[] = self::sessionFromRow($row);
     }
 
     return $sessions;
+  }
+
+  public static async function genEmptySessionsForCleanup(
+  ): Awaitable<array<Session>> {
+    $db = await self::genDb();
+    $sessions = array();
+    $result = await $db->queryf(
+      'SELECT * FROM sessions WHERE IFNULL(data, %s) = %s',
+      '',
+      '',
+    );
+
+    foreach ($result->mapRows() as $row) {
+      $sessions[] = self::sessionFromRow($row);
+    }
+
+    return $sessions;
+  }
+
+  // All the sessions
+  public static async function genAllSessions(
+    bool $refresh = false,
+  ): Awaitable<array<Session>> {
+    if ($refresh) {
+      $db = await self::genDb();
+      $sessions = array();
+      $result = await $db->queryf(
+        'SELECT * FROM sessions ORDER BY last_access_ts DESC',
+      );
+
+      $sessions = array();
+      foreach ($result->mapRows() as $row) {
+        $sessions[] = self::sessionFromRow($row);
+      }
+      return $sessions;
+    } else {
+      $mc = self::getMc();
+      $sessions = array();
+      $cached_sessions = array();
+      /* HH_IGNORE_ERROR[4053]: HHVM doesn't beleive there is a getAllKeys() method, there is... */
+      $mc_keys = $mc->getAllKeys();
+      $all_sessions = preg_grep(
+        "/".self::$MC_KEY.self::$MC_KEYS->get("SESSIONS")."/",
+        $mc_keys,
+      );
+      foreach ($all_sessions as $session_key) {
+        $session_key =
+          substr(strstr(substr(strstr($session_key, ":"), 1), ":"), 1);
+        $cached_sessions[] = $session_key;
+        $sessions[] = self::getMCSession($session_key);
+      }
+      $db = await self::genDb();
+      $result = await $db->queryf('SELECT * FROM sessions');
+
+      foreach ($result->mapRows() as $row) {
+        if (!in_array($row->get('cookie'), $cached_sessions)) {
+          $sessions[] = self::sessionFromRow($row);
+        }
+      }
+      /* HH_IGNORE_ERROR[4110]: getMCSession returns a 'mixed' type, HHVM is unsure of the type at this point */
+      return $sessions;
+    }
+  }
+
+  private static function setMCSession(string $key, mixed $records): void {
+    $mc = self::getMc();
+    $mc->set(
+      self::$MC_KEY.self::$MC_KEYS->get("SESSIONS").$key,
+      $records,
+      self::$MC_EXPIRE,
+    );
+  }
+
+  private static function getMCSession(string $key): mixed {
+    $mc = self::getMc();
+    $mc_result =
+      $mc->get(static::$MC_KEY.static::$MC_KEYS->get("SESSIONS").$key);
+    return $mc_result;
+  }
+
+  public static function invalidateMCSessions(?string $key = null): void {
+    $mc = self::getMc();
+    /* HH_IGNORE_ERROR[4053]: HHVM doesn't beleive there is a getAllKeys() method, there is... */
+    $mc_keys = $mc->getAllKeys();
+    if ($key === null) {
+      $all_sessions = preg_grep(
+        "/".self::$MC_KEY.self::$MC_KEYS->get("SESSIONS")."/",
+        $mc_keys,
+      );
+      foreach ($all_sessions as $session_key) {
+        $mc->delete($session_key);
+      }
+    } else {
+      $mc->delete(self::$MC_KEY.self::$MC_KEYS->get("SESSIONS").$key);
+    }
   }
 }

--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -146,14 +146,14 @@ class Session extends Model {
       invariant($result->numRows() === 1, 'Expected exactly one result');
       $session_data = self::sessionFromRow($result->mapRows()[0]);
       self::setMCSession($cookie, $session_data);
+      return $session_data;
+    } else {
+      invariant(
+        $mc_result instanceof Session,
+        'cache return should be of type Session',
+      );
+      return $mc_result;
     }
-    $session = self::getMCSession($cookie);
-    invariant($session !== null, 'session should not be null');
-    invariant(
-      $session instanceof Session,
-      'session should be of type Session',
-    );
-    return $session;
   }
 
   // Checks if session exists by cookie.
@@ -254,7 +254,6 @@ class Session extends Model {
     } else {
       await self::genCreateCacheSession($cookie);
     }
-    $sess = self::getMCSession($cookie);
   }
 
   // Delete the session for a given cookie.

--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -81,7 +81,6 @@ class Session extends Model {
     $session_data = Map {};
     $mc_result = self::getMCSession($cookie);
     if ($mc_result) {
-      invariant($mc_result !== null, 'mc_result should not be null');
       invariant(
         $mc_result instanceof Session,
         'mc_result should be of type Session',
@@ -196,7 +195,6 @@ class Session extends Model {
     }
     $session = self::getMCSession($cookie);
     if ($session) {
-      invariant($session !== null, 'session should not be null');
       invariant(
         $session instanceof Session,
         'session should be of type Session',
@@ -239,7 +237,6 @@ class Session extends Model {
     }
     $mc_result = self::getMCSession($cookie);
     if ($mc_result) {
-      invariant($mc_result !== null, 'session should not be null');
       invariant(
         $mc_result instanceof Session,
         'session should be of type Session',
@@ -313,10 +310,6 @@ class Session extends Model {
         continue;
       }
       invariant(
-        $cached_session !== null,
-        'cached_session should not be null',
-      );
-      invariant(
         $cached_session instanceof Session,
         'cached_session should be of type Session',
       );
@@ -334,14 +327,21 @@ class Session extends Model {
     }
     foreach ($empty_sessions as $session) {
       $cached_session = self::getMCSession($session->getCookie());
-      if ($cached_session !== false && $cached_session === '') {
+      if ($cached_session === false) {
+        continue;
+      }
+      invariant(
+        $cached_session instanceof Session,
+        'cached_session should be of type Session',
+      );
+      if ($cached_session->getData() === '') {
         self::invalidateMCSessions($session->getCookie());
-      } elseif ($cached_session !== false && $cached_session !== '') {
+      } else if ($cached_session->getData() !== '') {
         await self::genUpdate(
-            $session->getCookie(),
-            $session->getData(),
-            true,
-            );
+          $session->getCookie(),
+          $session->getData(),
+          true,
+        );
       }
     }
     // Clean up expired sessions

--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -309,6 +309,9 @@ class Session extends Model {
     $empty_sessions = await self::genEmptySessionsForCleanup();
     foreach ($expired_sessions as $session) {
       $cached_session = self::getMCSession($session->getCookie());
+      if ($cached_session === false) {
+        continue;
+      }
       invariant(
         $cached_session !== null,
         'cached_session should not be null',
@@ -333,6 +336,12 @@ class Session extends Model {
       $cached_session = self::getMCSession($session->getCookie());
       if ($cached_session !== false && $cached_session === '') {
         self::invalidateMCSessions($session->getCookie());
+      } elseif ($cached_session !== false && $cached_session !== '') {
+        await self::genUpdate(
+            $session->getCookie(),
+            $session->getData(),
+            true,
+            );
       }
     }
     // Clean up expired sessions

--- a/tests/models/SessionTest.php
+++ b/tests/models/SessionTest.php
@@ -14,14 +14,14 @@ class SessionTest extends FBCTFTest {
   }
 
   public function testCreate(): void {
-    HH\Asio\join(Session::genCreate('cookie 2', 'data 2'));
+    HH\Asio\join(Session::genCreate('cookie2', 'data2'));
     $all = HH\Asio\join(Session::genAllSessions());
     $this->assertEquals(2, count($all));
 
     $a = $all[0];
     $this->assertEquals(2, $a->getId());
-    $this->assertEquals('cookie 2', $a->getCookie());
-    $this->assertEquals('data 2', $a->getData());
+    $this->assertEquals('cookie2', $a->getCookie());
+    $this->assertEquals('data2', $a->getData());
     $this->assertEquals(1, $a->getTeamId());
   }
 }


### PR DESCRIPTION
* Sessions are still stored within the database; however, sessions are now replicated into Memcached.  By adding a Memcached layer on-top of Sessions, most session-related functions no longer require a query against the database, dramatically reducing the queries and improving performance.

* All session related functions are redundant; if the data is not found within the cache, but does exist in the database, it will be retrieved from the database and stored in the cache.  The redundancy ensures that failures or thrashing of Memcached do not invalidate valid sessions.

* Sessions are stored back to the database at the same frequently as they were prior to this update.  Specifically, the session is written to the database on each full-page load.

* The session cache is updated on every request, regardless of the type of request.  The continual update of the cached version of the session allows more granular updates of both 'last_access_ts' and 'last_access_page'.   The admin will always have the most up to date information available for display within the administrative Sessions page.

* As the session cache is more up-to-date, this can be used as a verification of expiration.  The old method allowed for sessions to timeout if a full page navigation did not take place within the allotted session lifetime, this is no longer the case.  If a sessions is marked as expired based on the database results, yet the cache version shows activity within the session lifetime span, the session is updated within the database and remains valid.

* Modals are specifically enforcing the various sessions updates.  The inclusion of modals in the session tracking allows for more specific 'last_access_page' values.