### PR TITLE
Updated Session Invalidation

### DIFF
--- a/src/models/Configuration.php
+++ b/src/models/Configuration.php
@@ -58,6 +58,9 @@ class Configuration extends Model {
       $value,
       $field,
     );
+    if ($field === 'login' && intval($value) === 0) {
+      await Session::genDeleteAllUnprotected();
+    }
 
     self::getMc()->delete(self::MC_KEY.$field);
   }

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -355,6 +355,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
+    await Session::genDeleteByTeam($team_id);
   }
 
   // Delete team.
@@ -366,6 +367,7 @@ class Team extends Model implements Importable, Exportable {
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
     Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    await Session::genDeleteByTeam($team_id);
   }
 
   // Enable or disable teams by passing 1 or 0.
@@ -379,6 +381,9 @@ class Team extends Model implements Importable, Exportable {
       $status ? 1 : 0,
       $team_id,
     );
+    if ($status === false) {
+      await Session::genDeleteByTeam($team_id);
+    }
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
@@ -389,6 +394,9 @@ class Team extends Model implements Importable, Exportable {
       'UPDATE teams SET active = %d WHERE id > 0 AND protected = 0',
       $status ? 1 : 0,
     );
+    if ($status === false) {
+      await Session::genDeleteAllUnprotected();
+    }
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
   }
 
@@ -404,6 +412,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
+    await Session::genDeleteByTeam($team_id); // Delete all sessions for team in question
   }
 
   // Enable or disable team visibility by passing 1 or 0.
@@ -584,6 +593,7 @@ class Team extends Model implements Importable, Exportable {
     $db = await self::genDb();
     await $db->queryf('UPDATE teams SET points = 0 WHERE id > 0');
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
+    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
   }
 
   // Teams total number.


### PR DESCRIPTION
* The new Session::getUnprotectedSessions() method returns all non-admin sessions and is now used in conjunction with the new Session::genDeleteAllUnprotected() method.  When an admin disables all teams, all non-administrative sessions are deleted and invalidated.

* Session::genDeleteByTeam is called to delete and invalidate team sessions on password update, team status toggle, and team deletion.

* Added condition to Configuration::genUpdate() to delete and invalidate all user sessions when an administrator disables login via the ‘login off’ admin toggle.

* The SQL limit was removed from Session::genDeleteByTeam() delete query. This resolves the issue where only one team session is being deleted after a team deletion.

* Updated the Team class to add session invalidation when team settings are changed or updated.  This includes invalidation of all related sessions when: the admin status is changed for a team, an individual team is disabled, all teams are disabled, a team’s password is updated, or a  team is deleted.