### PR TITLE
Added Cascading Delete for Team Deletion

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -2901,6 +2901,7 @@ class AdminController extends Controller {
       $team_admin_off = !$team->getAdmin();
       $team_visible_on = $team->getVisible();
       $team_visible_off = !$team->getVisible();
+      $team_id = strval($team->getId());
 
       $team_status_name = 'fb--teams--team-'.strval($team->getId()).'-status';
       $team_status_on_id =
@@ -2980,9 +2981,15 @@ class AdminController extends Controller {
             <label for={$team_admin_off_id}>{tr('Off')}</label>
           </div>;
         $delete_button =
-          <button class="fb-cta cta--red" data-action="delete">
-            {tr('Delete')}
-          </button>;
+          <div style="display: inline">
+            <input type="hidden" name="team_id" value={$team_id} />
+            <a
+              href="#"
+              class="fb-cta cta--red js-delete-team"
+              style="margin-right: 20px">
+              {tr('Delete')}
+            </a>
+          </div>;
       }
 
       $tab_team = 'team'.strval($team->getId());

--- a/src/controllers/modals/ActionModalController.php
+++ b/src/controllers/modals/ActionModalController.php
@@ -77,6 +77,28 @@ class ActionModalController extends ModalController {
             </div>
           </div>;
         return tuple($title, $content);
+      case 'delete-team':
+        $title =
+          <h4>
+            {tr('delete_')}<span class="highlighted">{tr('Team')}</span>
+          </h4>;
+        $content =
+          <div class="action-main">
+            <p>
+              {tr(
+                'Are you sure you want to delete this team? All data for this team will be irreversibly removed, including scoring logs. If you prefer to retain data, you can disable the team instead.',
+              )}
+            </p>
+            <div class="action-actionable">
+              <a href="#" class="fb-cta cta--red js-close-modal">
+                {tr('No')}
+              </a>
+              <a href="#" id="delete_team" class="fb-cta cta--yellow">
+                {tr('Yes')}
+              </a>
+            </div>
+          </div>;
+        return tuple($title, $content);
       case 'logout':
         $title =
           <h4>

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -365,6 +365,16 @@ class Team extends Model implements Importable, Exportable {
       'DELETE FROM teams WHERE id = %d AND protected = 0 LIMIT 1',
       $team_id,
     );
+    await $db->queryf(
+      'DELETE FROM registration_tokens WHERE team_id = %d',
+      $team_id,
+    );
+    await $db->queryf('DELETE FROM scores_log WHERE team_id = %d', $team_id);
+    await $db->queryf('DELETE FROM hints_log WHERE team_id = %d', $team_id);
+    await $db->queryf(
+      'DELETE FROM failures_log WHERE team_id = %d',
+      $team_id,
+    );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
     Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
     await Session::genDeleteByTeam($team_id);

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -37,6 +37,15 @@ function unpauseGame() {
   sendAdminRequest(unpause_data, true);
 }
 
+//Confirm team deletion
+function deleteTeamPopup(team_id) {
+  var delete_team = {
+    action: 'delete_team',
+    team_id: team_id
+  };
+  sendAdminRequest(delete_team, true);
+}
+
 /**
  * submits an ajax request to the admin endpoint
  *
@@ -1299,6 +1308,17 @@ module.exports = {
       event.preventDefault();
       Modal.loadPopup('p=action&modal=unpause-game', 'action-unpause-game', function() {
         $('#unpause_game').click(unpauseGame);
+      });
+    });
+
+    // prompt delete team
+    $('.js-delete-team').on('click', function(event) {
+      event.preventDefault();
+      var team_id = $(this).prev('input').attr('value');
+      Modal.loadPopup('p=action&modal=delete-team', 'action-delete-team', function() {
+        $('#delete_team').click(function() {
+          deleteTeamPopup(team_id);
+        });
       });
     });
 


### PR DESCRIPTION
* Added a confirmation dialog (modal) when an admin deletes a team.

* Ensured all team data is properly deleted from the relevant database tables.  The team data is now deleted from the team, registration_tokes, scores_log, hints_log, and failures_log tables.