### PR TITLE
Added Game Pause Functionality

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -184,11 +184,13 @@ CREATE TABLE `configuration` (
 
 LOCK TABLES `configuration` WRITE;
 INSERT INTO `configuration` (field, value, description) VALUES("game", "0", "(Boolean) Game is ongoing");
+INSERT INTO `configuration` (field, value, description) VALUES("game_paused", "0", "(Boolean) Game is paused");
 INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Date) Next game to happen");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_value", "3", "(Integer) Value of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_unit", "h", "(Character) Unit of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("start_ts", "0", "(Integer) Timestamp of start");
 INSERT INTO `configuration` (field, value, description) VALUES("end_ts", "0", "(Integer) Timestamp of end");
+INSERT INTO `configuration` (field, value, description) VALUES("pause_ts", "0", "(Integer) Timestamp of pause");
 INSERT INTO `configuration` (field, value, description) VALUES("timer", "0", "(Boolean) Timer is enabled");
 INSERT INTO `configuration` (field, value, description) VALUES("scoring", "0", "(Boolean) Ability score levels");
 INSERT INTO `configuration` (field, value, description) VALUES("gameboard", "1", "(Boolean) Refresh all data in the gameboard");

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -184,11 +184,13 @@ CREATE TABLE `configuration` (
 
 LOCK TABLES `configuration` WRITE;
 INSERT INTO `configuration` (field, value, description) VALUES("game", "0", "(Boolean) Game is ongoing");
+INSERT INTO `configuration` (field, value, description) VALUES("game_paused", "0", "(Boolean) Game is paused");
 INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Date) Next game to happen");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_value", "3", "(Integer) Value of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_unit", "h", "(Character) Unit of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("start_ts", "0", "(Integer) Timestamp of start");
 INSERT INTO `configuration` (field, value, description) VALUES("end_ts", "0", "(Integer) Timestamp of end");
+INSERT INTO `configuration` (field, value, description) VALUES("pause_ts", "0", "(Integer) Timestamp of pause");
 INSERT INTO `configuration` (field, value, description) VALUES("timer", "0", "(Boolean) Timer is enabled");
 INSERT INTO `configuration` (field, value, description) VALUES("scoring", "0", "(Boolean) Ability score levels");
 INSERT INTO `configuration` (field, value, description) VALUES("gameboard", "1", "(Boolean) Refresh all data in the gameboard");

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -3481,11 +3481,25 @@ class AdminController extends Controller {
   public async function genRenderMainNav(): Awaitable<:xhp> {
     $game = await Configuration::gen('game');
     $game_status = $game->getValue() === '1';
+    $pause_action = "";
     if ($game_status) {
       $game_action =
         <a href="#" class="fb-cta cta--red js-end-game">
           {tr('End Game')}
         </a>;
+      $pause = await Configuration::gen('game_paused');
+      $game_paused = $pause->getValue() === '1';
+      if ($game_paused) {
+        $pause_action =
+          <a href="#" class="fb-cta cta--yellow js-unpause-game">
+            {tr('Unpause Game')}
+          </a>;
+      } else {
+        $pause_action =
+          <a href="#" class="fb-cta cta--red js-pause-game">
+            {tr('Pause Game')}
+          </a>;
+      }
     } else {
       $game_action =
         <a href="#" class="fb-cta cta--yellow js-begin-game">
@@ -3557,6 +3571,8 @@ class AdminController extends Controller {
             </li>
           </ul>
           {$game_action}
+          <p><br /></p>
+          {$pause_action}
         </nav>
         <div class="admin-nav--footer row-fixed">
           <a href="/index.php?p=game">{tr('Gameboard')}</a>

--- a/src/controllers/ajax/AdminAjaxController.php
+++ b/src/controllers/ajax/AdminAjaxController.php
@@ -121,6 +121,8 @@ class AdminAjaxController extends AjaxController {
       'delete_announcement',
       'create_tokens',
       'end_game',
+      'pause_game',
+      'unpause_game',
       'reset_game',
       'backup_db',
       'export_game',
@@ -421,6 +423,12 @@ class AdminAjaxController extends AjaxController {
         return Utils::ok_response('Success', 'admin');
       case 'end_game':
         await Control::genEnd();
+        return Utils::ok_response('Success', 'admin');
+      case 'pause_game':
+        await Control::genPause();
+        return Utils::ok_response('Success', 'admin');
+      case 'unpause_game':
+        await Control::genUnPause();
         return Utils::ok_response('Success', 'admin');
       case 'backup_db':
         Control::backupDb();

--- a/src/controllers/modals/ActionModalController.php
+++ b/src/controllers/modals/ActionModalController.php
@@ -41,6 +41,42 @@ class ActionModalController extends ModalController {
             </div>
           </div>;
         return tuple($title, $content);
+      case 'pause-game':
+        $title =
+          <h4>
+            {tr('pause_')}<span class="highlighted">{tr('Game')}</span>
+          </h4>;
+        $content =
+          <div class="action-main">
+            <p>{tr('Are you sure you want to pause the current game?')}</p>
+            <div class="action-actionable">
+              <a href="#" class="fb-cta cta--red js-close-modal">
+                {tr('No')}
+              </a>
+              <a href="#" id="pause_game" class="fb-cta cta--yellow">
+                {tr('Yes')}
+              </a>
+            </div>
+          </div>;
+        return tuple($title, $content);
+      case 'unpause-game':
+        $title =
+          <h4>
+            {tr('unpause_')}<span class="highlighted">{tr('Game')}</span>
+          </h4>;
+        $content =
+          <div class="action-main">
+            <p>{tr('Are you sure you want to unpause the current game?')}</p>
+            <div class="action-actionable">
+              <a href="#" class="fb-cta cta--red js-close-modal">
+                {tr('No')}
+              </a>
+              <a href="#" id="unpause_game" class="fb-cta cta--yellow">
+                {tr('Yes')}
+              </a>
+            </div>
+          </div>;
+        return tuple($title, $content);
       case 'logout':
         $title =
           <h4>

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -92,6 +92,12 @@ class Control extends Model {
     $end_ts = $start_ts + $duration;
     await Configuration::genUpdate('end_ts', strval($end_ts));
 
+    // Set pause to zero
+    await Configuration::genUpdate('pause_ts', '0');
+
+    // Set gane to not paused
+    await Configuration::genUpdate('game_paused', '0');
+
     // Kick off timer
     await Configuration::genUpdate('timer', '1');
 
@@ -114,6 +120,38 @@ class Control extends Model {
     await Configuration::genUpdate('start_ts', '0');
     await Configuration::genUpdate('end_ts', '0');
 
+    // Set pause to zero
+    await Configuration::genUpdate('pause_ts', '0');
+
+    // Stop timer
+    await Configuration::genUpdate('timer', '0');
+
+    $pause = await Configuration::gen('game_paused');
+    $game_paused = $pause->getValue() === '1';
+
+    if (!$game_paused) {
+      // Stop bases scoring process
+      await Level::genStopBaseScoring();
+
+      // Stop progressive scoreboard process
+      await Progressive::genStop();
+    } else {
+      // Set game to not paused
+      await Configuration::genUpdate('game_paused', '0');
+    }
+  }
+
+  public static async function genPause(): Awaitable<void> {
+    // Disable scoring
+    await Configuration::genUpdate('scoring', '0');
+
+    // Set pause timestamp
+    $pause_ts = time();
+    await Configuration::genUpdate('pause_ts', strval($pause_ts));
+
+    // Set gane to paused
+    await Configuration::genUpdate('game_paused', '1');
+
     // Stop timer
     await Configuration::genUpdate('timer', '0');
 
@@ -122,6 +160,47 @@ class Control extends Model {
 
     // Stop progressive scoreboard process
     await Progressive::genStop();
+  }
+
+  public static async function genUnPause(): Awaitable<void> {
+    // Enable scoring
+    await Configuration::genUpdate('scoring', '1');
+
+    // Get pause time
+    $config_pause_ts = await Configuration::gen('pause_ts');
+    $pause_ts = intval($config_pause_ts->getValue());
+
+    // Get start time
+    $config_start_ts = await Configuration::gen('start_ts');
+    $start_ts = intval($config_start_ts->getValue());
+
+    // Get end time
+    $config_end_ts = await Configuration::gen('end_ts');
+    $end_ts = intval($config_end_ts->getValue());
+
+    // Calulcate game remaining
+    $game_duration = $end_ts - $start_ts;
+    $game_played_duration = $pause_ts - $start_ts;
+    $remaining_duration = $game_duration - $game_played_duration;
+    $end_ts = time() + $remaining_duration;
+
+    // Set new endtime
+    await Configuration::genUpdate('end_ts', strval($end_ts));
+
+    // Set pause to zero
+    await Configuration::genUpdate('pause_ts', '0');
+
+    // Set gane to not paused
+    await Configuration::genUpdate('game_paused', '0');
+
+    // Start timer
+    await Configuration::genUpdate('timer', '1');
+
+    // Kick off progressive scoreboard
+    await Progressive::genRun();
+
+    // Kick off scoring for bases
+    await Level::genBaseScoring();
   }
 
   public static async function importGame(): Awaitable<bool> {

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -21,6 +21,22 @@ function endGame() {
   sendAdminRequest(end_data, true);
 }
 
+// Pauses the currently running game
+function pauseGame() {
+  var pause_data = {
+    action: 'pause_game'
+  };
+  sendAdminRequest(pause_data, true);
+}
+
+// Unuauses the currently running game
+function unpauseGame() {
+  var unpause_data = {
+    action: 'unpause_game'
+  };
+  sendAdminRequest(unpause_data, true);
+}
+
 /**
  * submits an ajax request to the admin endpoint
  *
@@ -1267,6 +1283,22 @@ module.exports = {
       event.preventDefault();
       Modal.loadPopup('p=action&modal=end-game', 'action-end-game', function() {
         $('#end_game').click(endGame);
+      });
+    });
+
+    // prompt pause game
+    $('.js-pause-game').on('click', function(event) {
+      event.preventDefault();
+      Modal.loadPopup('p=action&modal=pause-game', 'action-pause-game', function() {
+        $('#pause_game').click(pauseGame);
+      });
+    });
+
+    // prompt pause game
+    $('.js-unpause-game').on('click', function(event) {
+      event.preventDefault();
+      Modal.loadPopup('p=action&modal=unpause-game', 'action-unpause-game', function() {
+        $('#unpause_game').click(unpauseGame);
       });
     });
 


### PR DESCRIPTION
* Administrator's can now pause a running game, which will disable scoring and the running timer.  Upon resuming the game, the end-time will be appropriately moved forward so that the game will last the desired amount of time.

* Created Control::genPause() and Control::genUnPause() to handle the pause and unpause functionality.

* Control::genPause() disables the timer, scoring, bases, and progressive scoreboard, and stores the pause timestamp.

* Control::genUnPause() reenables the timer, scoring, bases, and progressive scoreboard, and extends the end timestamp based on the amount of time the game was paused.

* Pause/Unpause button added to the admin page

* Database has been updated to include a pause status and pause timestamp in the Configuration table.

* Relevant Modals and JavaScript has been added to handle the new pause functionality.