### PR TITLE
Added Game Schedule Functionality

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE `configuration` (
 LOCK TABLES `configuration` WRITE;
 INSERT INTO `configuration` (field, value, description) VALUES("game", "0", "(Boolean) Game is ongoing");
 INSERT INTO `configuration` (field, value, description) VALUES("game_paused", "0", "(Boolean) Game is paused");
-INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Date) Next game to happen");
+INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Integer) Next game to happen");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_value", "3", "(Integer) Value of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_unit", "h", "(Character) Unit of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("start_ts", "0", "(Integer) Timestamp of start");

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -185,7 +185,7 @@ CREATE TABLE `configuration` (
 LOCK TABLES `configuration` WRITE;
 INSERT INTO `configuration` (field, value, description) VALUES("game", "0", "(Boolean) Game is ongoing");
 INSERT INTO `configuration` (field, value, description) VALUES("game_paused", "0", "(Boolean) Game is paused");
-INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Date) Next game to happen");
+INSERT INTO `configuration` (field, value, description) VALUES("next_game", "0", "(Integer) Next game to happen");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_value", "3", "(Integer) Value of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("game_duration_unit", "h", "(Character) Unit of the duration of the game");
 INSERT INTO `configuration` (field, value, description) VALUES("start_ts", "0", "(Integer) Timestamp of start");

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -272,6 +272,7 @@ class AdminController extends Controller {
 
   public async function genRenderConfigurationContent(): Awaitable<:xhp> {
     $awaitables = Map {
+      'game' => Configuration::gen('game'),
       'registration' => Configuration::gen('registration'),
       'registration_players' => Configuration::gen('registration_players'),
       'login' => Configuration::gen('login'),
@@ -295,6 +296,7 @@ class AdminController extends Controller {
 
     $results = await \HH\Asio\m($awaitables);
 
+    $game = $results['game'];
     $registration = $results['registration'];
     $registration_players = $results['registration_players'];
     $login = $results['login'];
@@ -334,12 +336,45 @@ class AdminController extends Controller {
     $timer_on = $timer->getValue() === '1';
     $timer_off = $timer->getValue() === '0';
 
-    if ($start_ts->getValue() === '0') {
-      $start_ts = tr('Not started yet');
-      $end_ts = tr('Not started yet');
+    if ($start_ts->getValue() !== '0' && $start_ts->getValue() !== 'NaN') {
+      $game_start_ts = $start_ts->getValue();
+      $game_start_year = date('Y', $game_start_ts);
+      $game_start_month = date('n', $game_start_ts);
+      $game_start_day = date('j', $game_start_ts);
+      $game_start_hour = date('G', $game_start_ts);
+      $game_start_min = date('i', $game_start_ts);
     } else {
-      $start_ts = date(tr('date and time format'), $start_ts->getValue());
-      $end_ts = date(tr('date and time format'), $end_ts->getValue());
+      $game_start_ts = '0';
+      $game_start_year = '0';
+      $game_start_month = '0';
+      $game_start_day = '0';
+      $game_start_hour = '0';
+      $game_start_min = '0';
+    }
+
+    if ($end_ts->getValue() !== '0' && $end_ts->getValue() !== 'NaN') {
+      $game_end_ts = $end_ts->getValue();
+      $game_end_year = date('Y', $game_end_ts);
+      $game_end_month = date('n', $game_end_ts);
+      $game_end_day = date('j', $game_end_ts);
+      $game_end_hour = date('G', $game_end_ts);
+      $game_end_min = date('i', $game_end_ts);
+    } else {
+      $game_end_ts = '0';
+      $game_end_year = '0';
+      $game_end_month = '0';
+      $game_end_day = '0';
+      $game_end_hour = '0';
+      $game_end_min = '0';
+    }
+
+    if ($game->getValue() === '0') {
+      $timer_start_ts = tr('Not started yet');
+      $timer_end_ts = tr('Not started yet');
+    } else {
+      $timer_start_ts =
+        date(tr('date and time format'), $start_ts->getValue());
+      $timer_end_ts = date(tr('date and time format'), $end_ts->getValue());
     }
 
     $registration_type = await Configuration::gen('registration_type');
@@ -691,6 +726,103 @@ class AdminController extends Controller {
               </section>
               <section class="admin-box">
                 <header class="admin-box-header">
+                  <h3>{tr('Game Schedule')}</h3>
+                </header>
+                <div class="fb-column-container">
+                  <div class="col col-pad col-1-5">
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Game Start Year')}</label>
+                      <input
+                        type="number"
+                        value={$game_start_year}
+                        name="fb--schedule--start_year"
+                      />
+                    </div>
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Game End Year')}</label>
+                      <input
+                        type="number"
+                        value={$game_end_year}
+                        name="fb--schedule--end_year"
+                      />
+                    </div>
+                  </div>
+                  <div class="col col-pad col-2-5">
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Month')}</label>
+                      <input
+                        type="number"
+                        value={$game_start_month}
+                        name="fb--schedule--start_month"
+                      />
+                    </div>
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Month')}</label>
+                      <input
+                        type="number"
+                        value={$game_end_month}
+                        name="fb--schedule--end_month"
+                      />
+                    </div>
+                  </div>
+                  <div class="col col-pad col-3-5">
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Day')}</label>
+                      <input
+                        type="number"
+                        value={$game_start_day}
+                        name="fb--schedule--start_day"
+                      />
+                    </div>
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Day')}</label>
+                      <input
+                        type="number"
+                        value={$game_end_day}
+                        name="fb--schedule--end_day"
+                      />
+                    </div>
+                  </div>
+                  <div class="col col-pad col-4-5">
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Hour')}</label>
+                      <input
+                        type="number"
+                        value={$game_start_hour}
+                        name="fb--schedule--start_hour"
+                      />
+                    </div>
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Hour')}</label>
+                      <input
+                        type="number"
+                        value={$game_end_hour}
+                        name="fb--schedule--end_hour"
+                      />
+                    </div>
+                  </div>
+                  <div class="col col-pad col-5-5">
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Minute')}</label>
+                      <input
+                        type="number"
+                        value={$game_start_min}
+                        name="fb--schedule--start_min"
+                      />
+                    </div>
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Minute')}</label>
+                      <input
+                        type="number"
+                        value={$game_end_min}
+                        name="fb--schedule--end_min"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section class="admin-box">
+                <header class="admin-box-header">
                   <h3>{tr('Timer')}</h3>
                   <div class="admin-section-toggle radio-inline">
                     <input
@@ -727,23 +859,23 @@ class AdminController extends Controller {
                       {$configuration_duration_select}
                     </div>
                   </div>
-                  <div class="col col-pad col-2-4">
+                  <div class="col col-pad col-3-4">
                     <div class="form-el el--block-label el--full-text">
                       <label for="">{tr('Begin Time')}</label>
                       <input
                         type="text"
-                        value={$start_ts}
+                        value={$timer_start_ts}
                         id="fb--conf--start_ts"
                         disabled={true}
                       />
                     </div>
                   </div>
-                  <div class="col col-pad col-3-4">
+                  <div class="col col-pad col-4-4">
                     <div class="form-el el--block-label el--full-text">
                       <label for="">{tr('Expected End Time')}</label>
                       <input
                         type="text"
-                        value={$end_ts}
+                        value={$timer_end_ts}
                         id="fb--conf--end_ts"
                         disabled={true}
                       />

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -336,36 +336,30 @@ class AdminController extends Controller {
     $timer_on = $timer->getValue() === '1';
     $timer_off = $timer->getValue() === '0';
 
+    $game_start_array = array();
     if ($start_ts->getValue() !== '0' && $start_ts->getValue() !== 'NaN') {
       $game_start_ts = $start_ts->getValue();
-      $game_start_year = date('Y', $game_start_ts);
-      $game_start_month = date('n', $game_start_ts);
-      $game_start_day = date('j', $game_start_ts);
-      $game_start_hour = date('G', $game_start_ts);
-      $game_start_min = date('i', $game_start_ts);
+      $game_start_array = getdate($game_start_ts);
     } else {
       $game_start_ts = '0';
-      $game_start_year = '0';
-      $game_start_month = '0';
-      $game_start_day = '0';
-      $game_start_hour = '0';
-      $game_start_min = '0';
+      $game_start_array['year'] = '0';
+      $game_start_array['mon'] = '0';
+      $game_start_array['mday'] = '0';
+      $game_start_array['hours'] = '0';
+      $game_start_array['minutes'] = '0';
     }
 
+    $game_end_array = array();
     if ($end_ts->getValue() !== '0' && $end_ts->getValue() !== 'NaN') {
       $game_end_ts = $end_ts->getValue();
-      $game_end_year = date('Y', $game_end_ts);
-      $game_end_month = date('n', $game_end_ts);
-      $game_end_day = date('j', $game_end_ts);
-      $game_end_hour = date('G', $game_end_ts);
-      $game_end_min = date('i', $game_end_ts);
+      $game_end_array = getdate($game_end_ts);
     } else {
       $game_end_ts = '0';
-      $game_end_year = '0';
-      $game_end_month = '0';
-      $game_end_day = '0';
-      $game_end_hour = '0';
-      $game_end_min = '0';
+      $game_end_array['year'] = '0';
+      $game_end_array['mon'] = '0';
+      $game_end_array['mday'] = '0';
+      $game_end_array['hours'] = '0';
+      $game_end_array['minutes'] = '0';
     }
 
     if ($game->getValue() === '0') {
@@ -734,7 +728,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Game Start Year')}</label>
                       <input
                         type="number"
-                        value={$game_start_year}
+                        value={strval($game_start_array['year'])}
                         name="fb--schedule--start_year"
                       />
                     </div>
@@ -742,7 +736,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Game End Year')}</label>
                       <input
                         type="number"
-                        value={$game_end_year}
+                        value={strval($game_end_array['year'])}
                         name="fb--schedule--end_year"
                       />
                     </div>
@@ -752,7 +746,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Month')}</label>
                       <input
                         type="number"
-                        value={$game_start_month}
+                        value={strval($game_start_array['mon'])}
                         name="fb--schedule--start_month"
                       />
                     </div>
@@ -760,7 +754,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Month')}</label>
                       <input
                         type="number"
-                        value={$game_end_month}
+                        value={strval($game_end_array['mon'])}
                         name="fb--schedule--end_month"
                       />
                     </div>
@@ -770,7 +764,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Day')}</label>
                       <input
                         type="number"
-                        value={$game_start_day}
+                        value={strval($game_start_array['mday'])}
                         name="fb--schedule--start_day"
                       />
                     </div>
@@ -778,7 +772,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Day')}</label>
                       <input
                         type="number"
-                        value={$game_end_day}
+                        value={strval($game_end_array['mday'])}
                         name="fb--schedule--end_day"
                       />
                     </div>
@@ -788,7 +782,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Hour')}</label>
                       <input
                         type="number"
-                        value={$game_start_hour}
+                        value={strval($game_start_array['hours'])}
                         name="fb--schedule--start_hour"
                       />
                     </div>
@@ -796,7 +790,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Hour')}</label>
                       <input
                         type="number"
-                        value={$game_end_hour}
+                        value={strval($game_end_array['hours'])}
                         name="fb--schedule--end_hour"
                       />
                     </div>
@@ -806,7 +800,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Minute')}</label>
                       <input
                         type="number"
-                        value={$game_start_min}
+                        value={strval($game_start_array['minutes'])}
                         name="fb--schedule--start_min"
                       />
                     </div>
@@ -814,7 +808,7 @@ class AdminController extends Controller {
                       <label for="">{tr('Minute')}</label>
                       <input
                         type="number"
-                        value={$game_end_min}
+                        value={strval($game_end_array['minutes'])}
                         name="fb--schedule--end_min"
                       />
                     </div>

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -109,10 +109,21 @@ class IndexController extends Controller {
     }
     $next_game = await Configuration::gen('next_game');
     $next_game = $next_game->getValue();
-    if ($next_game === "0") {
+    $game = await Configuration::gen('game');
+    $game = $game->getValue();
+    if ($game === '1') {
+      $next_game_text = tr('In Progress');
+      $countdown = array('--', '--', '--', '--');
+    } else if ($next_game === '0' || intval($next_game) < time()) {
       $next_game_text = tr('Soon');
+      $countdown = array('--', '--', '--', '--');
     } else {
-      $next_game_text = $next_game;
+      $next_game_text = date(tr('date and time format'), $next_game);
+      $game_start = new DateTime();
+      $game_start->setTimestamp(intval($next_game));
+      $now = new DateTime('now');
+      $countdown_diff = $now->diff($game_start);
+      $countdown = explode('-', $countdown_diff->format('%d-%h-%i-%s'));
     }
     return
       <div class="fb-row-container full-height fb-scroll">
@@ -126,10 +137,22 @@ class IndexController extends Controller {
               {$next_game_text}
             </h1>
             <ul class="upcoming-game-countdown">
-              <li><span class="count-number">--</span>{tr('_days')}</li>
-              <li><span class="count-number">--</span>{tr('_hours')}</li>
-              <li><span class="count-number">--</span>{tr('_minutes')}</li>
-              <li><span class="count-number">--</span>{tr('_seconds')}</li>
+              <li>
+                <span class="count-number">{$countdown[0]}</span>
+                {tr('_days')}
+              </li>
+              <li>
+                <span class="count-number">{$countdown[1]}</span>
+                {tr('_hours')}
+              </li>
+              <li>
+                <span class="count-number">{$countdown[2]}</span>
+                {tr('_minutes')}
+              </li>
+              <li>
+                <span class="count-number">{$countdown[3]}</span>
+                {tr('_seconds')}
+              </li>
             </ul>
             {$play_nav}
           </div>

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -1130,6 +1130,29 @@ module.exports = {
       }
     });
 
+    // game schedule fields
+    $('input[type="number"][name^="fb--schedule"]').on('change', function() {
+      var start_year = $('input[type="number"][name="fb--schedule--start_year"]')[0].value;
+      var start_month = $('input[type="number"][name="fb--schedule--start_month"]')[0].value;
+      var start_day = $('input[type="number"][name="fb--schedule--start_day"]')[0].value;
+      var start_hour = $('input[type="number"][name="fb--schedule--start_hour"]')[0].value;
+      var start_min = $('input[type="number"][name="fb--schedule--start_min"]')[0].value;
+      var start_ts = new Date(start_month + "/" + start_day + "/" + start_year + " " + start_hour + ":" + start_min).getTime() / 1000;
+      if ($.isNumeric(start_ts)) {
+        changeConfiguration("start_ts", start_ts);
+        changeConfiguration("next_game", start_ts);
+      }
+      var end_year = $('input[type="number"][name="fb--schedule--end_year"]')[0].value;
+      var end_month = $('input[type="number"][name="fb--schedule--end_month"]')[0].value;
+      var end_day = $('input[type="number"][name="fb--schedule--end_day"]')[0].value;
+      var end_hour = $('input[type="number"][name="fb--schedule--end_hour"]')[0].value;
+      var end_min = $('input[type="number"][name="fb--schedule--end_min"]')[0].value;
+      var end_ts = new Date(end_month + "/" + end_day + "/" + end_year + " " + end_hour + ":" + end_min).getTime() / 1000;
+      if ($.isNumeric(end_ts)) {
+        changeConfiguration("end_ts", end_ts);
+      }
+    });
+
     // modal actionable
     $body.on('click', '.js-confirm-save', function() {
       var $status = $('.admin-section--status .highlighted');


### PR DESCRIPTION
![fbctf_game_schedule](https://cloud.githubusercontent.com/assets/22864312/21066204/5a76310c-be32-11e6-8dad-9844d089e1ab.gif)

* Allow an administrator to set the start and end date/time for the game.

* If the game has not started and is set to start in the future the "countdown" page will display the date of the upcoming game and the time remaining until the game begins.

* If the game is currently running the "countdown" page will display "In Progress."

* If no game is schedule the "countdown" page will display the default of "Soon."

* The administrator can change the end date/time of the game at any point and the various timers/displays will update appropriately.

* Configuration table within the database has been updated to define the data type found in the "next_game" field.

* JavaScript have been updated to handle the submission and processing of the new schedule fields on the admin Configuration page.

* Note: This PR does NOT perform any automation of the game starting or stopping, instead simply providing scheduling capability which will impact the various timers.