### PR TITLE
CTF could not be started due to syntax and head error in controller.php

### DIFF
--- a/src/controllers/Controller.php
+++ b/src/controllers/Controller.php
@@ -13,13 +13,16 @@ abstract class Controller {
 	$config = await Configuration::gen('language');
     $language = $config->getValue();
 	$document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
-	$localize_style="";
+    $localize_style = '';
 	if (! preg_match('/^\w{2}$/', $language)) {
 		$language = "en";
 	}
 	if (file_exists($document_root."/static/css/locals/".$language."/style.css")){
-		$localize_style = <link rel="stylesheet" href="static/css/locals/".$language."/style.css" />
+		$localize_style = '"static/css/locals/'.$language.'/style.css"';
 	}
+    else {
+        $localize_style = '"static/css/locals/fa/style.css"';
+    }
     return
       <x:doctype>
         <html lang={$language}>
@@ -38,7 +41,7 @@ abstract class Controller {
               href="static/img/favicon.png"
             />
             <link rel="stylesheet" href="static/css/fb-ctf.css" />
-			{$localize_style}
+			<link rel="stylesheet" href={$localize_style} />
           </head>
           {$body}
         </html>


### PR DESCRIPTION
Hello,
I found 2 Bugs in the last commit. The CTF can't be loaded at the current state of the master. 
I looked up the log and saw following erros which i fixed:

[hphp] [12832:7fba49bff700:3:000001] [] \nFatal error: Unexpected character in input: '.' (ASCII=46) (Line: 21, Char:
 69)\nsyntax error, unexpected '.', expecting '/' or T_XHP_LABEL or T_XHP_TAG_GT in /var/www/fbctf/src/controllers/Controller.php on line 21

[hphp] [12832:7fba49bff700:12:000001] [] \nFatal error: Uncaught exception 'XHPInvalidChildrenException' with message
 'Element `head` was rendered with invalid children.
