### PR TITLE
Updated Session Caching

### DIFF
--- a/src/models/Session.php
+++ b/src/models/Session.php
@@ -170,6 +170,7 @@ class Session extends Model {
       invariant($result->numRows() === 1, 'Expected exactly one result');
       if (intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0) {
         await self::genCreateCacheSession($cookie);
+        return true;
       }
     }
     return self::getMCSession($cookie) != false;
@@ -188,7 +189,8 @@ class Session extends Model {
       );
 
       if ($result->numRows() === 1) {
-        await self::genCreateCacheSession($cookie);
+        $session = await self::gen($cookie);
+        return $session->getData();
       } else {
         return '';
       }


### PR DESCRIPTION
* Sessions will now properly function when Memcached fails or is not present.  When Memcached is in use the added benefits, including more granular user tracking, will be enabled.  If Memcached is not present, the sessions will be directly handled by the database.

* This resolves issues #373 and #375