### PR TITLE
Autostart Memcached in Docker

### DIFF
--- a/extra/service_startup.sh
+++ b/extra/service_startup.sh
@@ -9,6 +9,7 @@ fi
 service hhvm restart
 service nginx restart
 service mysql restart
+service memcached restart
 
 chown www-data:www-data /var/run/hhvm/sock
 


### PR DESCRIPTION
* Ensure Memcached is automatically started in Docker containers.  Memcached is not required but dramatically improves performance.

* This resolves issues #373 and #375