### PR TITLE
Allow Admin Login When Team Login Disabled

### DIFF
--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -334,7 +334,9 @@ class IndexController extends Controller {
             <div class="fb-choose-emblem">
               <h6>{tr('Choose an Emblem')}</h6>
               <h6>
-                <a href="#" id="custom-emblem-link">{tr('or upload your own')}</a>
+                <a href="#" id="custom-emblem-link">
+                  {tr('or upload your own')}
+                </a>
               </h6>
               <div class="custom-emblem">
                 <input
@@ -607,6 +609,53 @@ class IndexController extends Controller {
             </form>
           </div>
         </main>;
+    } else if (Utils::getGET()->get('admin') === 'true') {
+      return
+        <main role="main" class="fb-main page--login full-height fb-scroll">
+          <header class="fb-section-header fb-container">
+            <h1 class="fb-glitch" data-text={tr('Admin Login')}>
+              {tr('Admin Login')}
+            </h1>
+            <p class="inner-container">
+              {tr(
+                'Team login is disabled. Only admins can login at this time. ',
+              )}
+            </p>
+          </header>
+          <div class="fb-login">
+            <form class="fb-form">
+              <input type="hidden" name="action" value="login_team" />
+              <input type="hidden" name="login_select" value={"off"} />
+              <fieldset class="form-set fb-container container--small">
+                <div class="form-el el--text">
+                  <label for="">{tr('Team Name')}</label>
+                  <input
+                    autocomplete="off"
+                    name="team_name"
+                    type="text"
+                    maxlength={20}
+                  />
+                </div>
+                <div class="form-el el--text">
+                  <label for="">{tr('Password')}</label>
+                  <input
+                    autocomplete="off"
+                    name="password"
+                    type="password"
+                  />
+                </div>
+              </fieldset>
+              <div class="form-el--actions">
+                <button
+                  id="login_button"
+                  class="fb-cta cta--yellow"
+                  type="button">
+                  {tr('Login')}
+                </button>
+              </div>
+            </form>
+          </div>
+        </main>;
     } else {
       return
         <div class="fb-row-container full-height fb-scroll">
@@ -624,6 +673,11 @@ class IndexController extends Controller {
                 <div class="form-el--actions">
                   <a href="/index.php?page=login" class="fb-cta cta--yellow">
                     {tr('Try Again')}
+                  </a>
+                </div>
+                <div class="form-el--actions">
+                  <a href="/index.php?page=login&admin=true" class="fb-cta">
+                    {tr('Admin Login')}
                   </a>
                 </div>
               </form>

--- a/src/controllers/ajax/IndexAjaxController.php
+++ b/src/controllers/ajax/IndexAjaxController.php
@@ -226,7 +226,7 @@ class IndexAjaxController extends AjaxController {
     // Check if login is disabled and this isn't an admin
     $login = await Configuration::gen('login');
     if (($login->getValue() === '0') &&
-        (!$team || (($team) && ($team->getAdmin() === false)))) {
+        ($team === null || $team->getAdmin() === false)) {
       return Utils::error_response('Login failed', 'login');
     }
 

--- a/src/controllers/ajax/IndexAjaxController.php
+++ b/src/controllers/ajax/IndexAjaxController.php
@@ -220,15 +220,17 @@ class IndexAjaxController extends AjaxController {
     int $team_id,
     string $password,
   ): Awaitable<string> {
-    // Check if login is enabled
+    // Verify credentials first so we can allow admins to login regardless of the login setting
+    $team = await Team::genVerifyCredentials($team_id, $password);
+
+    // Check if login is disabled and this isn't an admin
     $login = await Configuration::gen('login');
-    if ($login->getValue() === '0') {
+    if (($login->getValue() === '0') &&
+        (!$team || (($team) && ($team->getAdmin() === false)))) {
       return Utils::error_response('Login failed', 'login');
     }
 
-    // Verify credentials
-    $team = await Team::genVerifyCredentials($team_id, $password);
-
+    // Otherwise let's login any valid attempt
     if ($team) {
       SessionUtils::sessionRefresh();
       if (!SessionUtils::sessionActive()) {


### PR DESCRIPTION
* Added an "Admin Login" button to the disabled login page.

<img width="782" alt="login_disabled" src="https://cloud.githubusercontent.com/assets/22864312/22180520/379ac866-e040-11e6-8d74-605862221ef7.png">

* Only valid admin accounts can login when team login is disabled.

* Provide notice to users that only an admin can login at the time (when team login is disabled).

<img width="628" alt="admin_login" src="https://cloud.githubusercontent.com/assets/22864312/22180527/422070b0-e040-11e6-819e-a05440fc1dc8.png">
