### PR TITLE
Fix fail error

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -2699,7 +2699,7 @@ class AdminController extends Controller {
     if (count($failures) > 0) {
       $failures_tbody = <tbody></tbody>;
       foreach ($failures as $failure) {
-		if(!$genCheckStatus($failure->getLevelId())){
+		if(!Level::genCheckStatus($failure->getLevelId())){
 			continue;
 		}
         $level = await Level::gen($failure->getLevelId());


### PR DESCRIPTION
Throw this error:

> [Sun Jan 22 20:18:19 2017] [hphp] [13528:7f3ebf7ff700:4:000001] [] \nNotice: Undefined variable: genCheckStatus in /var/www/fbctf/src/controllers/AdminController.php on line 2702
> 
> [Sun Jan 22 20:18:19 2017] [hphp] [13528:7f3ebf7ff700:4:000002] [] \nFatal error: Function name must be a string in /var/www/fbctf/src/controllers/AdminController.php on line 2702
