### PR TITLE
Flush Memcached and Reset Database Admin Utilities

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -913,6 +913,33 @@ class AdminController extends Controller {
           </section>
           <section class="admin-box">
             <header class="admin-box-header">
+              <h3>{tr('Utilities')}</h3>
+            </header>
+            <div class="fb-column-container">
+              <div class="col col-pad col-1-4">
+                <div class="form-el el--block-label el--full-text">
+                  <div class="admin-buttons">
+                    <button
+                      class="fb-cta cta--yellow"
+                      data-action="flush-memcached">
+                      {tr('Flush Memcached')}
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="col col-pad col-1-4">
+                <div class="form-el el--block-label el--full-text">
+                  <div class="admin-buttons">
+                    <button class="fb-cta cta--red js-reset-database">
+                      {tr('Reset Database')}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section class="admin-box">
+            <header class="admin-box-header">
               <h3>{tr('Teams')}</h3>
             </header>
             <div class="fb-column-container">
@@ -2699,9 +2726,9 @@ class AdminController extends Controller {
     if (count($failures) > 0) {
       $failures_tbody = <tbody></tbody>;
       foreach ($failures as $failure) {
-		if(!Level::genCheckStatus($failure->getLevelId())){
-			continue;
-		}
+        if (!Level::genCheckStatus($failure->getLevelId())) {
+          continue;
+        }
         $level = await Level::gen($failure->getLevelId());
         $country = await Country::gen($level->getEntityId());
         $level_str = $country->getName().' - '.$level->getTitle();

--- a/src/controllers/ajax/AdminAjaxController.php
+++ b/src/controllers/ajax/AdminAjaxController.php
@@ -135,6 +135,8 @@ class AdminAjaxController extends AjaxController {
       'import_logos',
       'import_levels',
       'import_categories',
+      'flush_memcached',
+      'reset_database',
     );
   }
 
@@ -478,6 +480,18 @@ class AdminAjaxController extends AjaxController {
           return Utils::ok_response('Success', 'admin');
         }
         return Utils::error_response('Error importing', 'admin');
+      case 'flush_memcached':
+        $result = await Control::genFlushMemcached();
+        if ($result) {
+          return Utils::ok_response('Success', 'admin');
+        }
+        return Utils::error_response('Error flushing memcached', 'admin');
+      case 'reset_database':
+        $result = await Control::genResetDatabase();
+        if ($result) {
+          return Utils::ok_response('Success', 'admin');
+        }
+        return Utils::error_response('Error resetting database', 'admin');
       default:
         return Utils::error_response('Invalid action', 'admin');
     }

--- a/src/controllers/modals/ActionModalController.php
+++ b/src/controllers/modals/ActionModalController.php
@@ -197,6 +197,28 @@ class ActionModalController extends ModalController {
             </div>
           </div>;
         return tuple($title, $content);
+      case 'reset-database':
+        $title =
+          <h4>
+            {tr('reset_')}<span class="highlighted">{tr('Database')}</span>
+          </h4>;
+        $content =
+          <div class="action-main">
+            <p>
+              {tr(
+                'Are you sure you want to reset the database? This will destroy ALL data! Admin accounts will remain.',
+              )}
+            </p>
+            <div class="action-actionable">
+              <a href="#" class="fb-cta cta--red js-close-modal">
+                {tr('No')}
+              </a>
+              <a href="#" id="reset_database" class="fb-cta cta--yellow">
+                {tr('Yes')}
+              </a>
+            </div>
+          </div>;
+        return tuple($title, $content);
       default:
         invariant(false, "Invalid modal name $modal");
     }

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -354,4 +354,45 @@ class Control extends Model {
     $db = await self::genDb();
     await $db->queryf('DELETE FROM bases_log WHERE id > 0');
   }
+
+  public static async function genFlushMemcached(): Awaitable<bool> {
+    $mc = self::getMc();
+    return $mc->flush(0);
+  }
+
+  private static async function genLoadDatabaseFile(
+    string $file,
+  ): Awaitable<bool> {
+    $contents = file_get_contents($file);
+    if ($contents) {
+      $schema = explode(";", $contents);
+      $db = await self::genDb();
+      $result = await $db->multiQuery($schema);
+      return $result ? true : false;
+    }
+    return false;
+  }
+
+  public static async function genResetDatabase(): Awaitable<bool> {
+    $admins = await MultiTeam::genAllAdmins();
+    $schema = await self::genLoadDatabaseFile('../database/schema.sql');
+    $countries = await self::genLoadDatabaseFile('../database/countries.sql');
+    $logos = await self::genLoadDatabaseFile('../database/logos.sql');
+    if ($schema && $countries && $logos) {
+      foreach ($admins as $admin) {
+        await Team::genCreate(
+          $admin->getName(),
+          $admin->getPasswordHash(),
+          $admin->getLogo(),
+        );
+      }
+      $teams = await MultiTeam::genAllTeamsCache();
+      foreach ($teams as $team) {
+        await Team::genSetAdmin($team->getId(), true);
+      }
+      await self::genFlushMemcached();
+      return true;
+    }
+    return false;
+  }
 }

--- a/src/models/MultiTeam.php
+++ b/src/models/MultiTeam.php
@@ -25,6 +25,17 @@ class MultiTeam extends Team {
     return $result->mapRows();
   }
 
+  public static async function genAllAdmins(): Awaitable<array<Team>> {
+    $admins = await MultiTeam::genTeamArrayFromDB(
+      'SELECT * FROM teams WHERE admin = 1',
+    );
+    $admin_teams = array();
+    foreach ($admins->items() as $admin) {
+      $admin_teams[] = Team::teamFromRow($admin);
+    }
+    return $admin_teams;
+  }
+
   // All teams.
   public static async function genAllTeamsCache(
     bool $refresh = false,

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -46,6 +46,14 @@ function deleteTeamPopup(team_id) {
   sendAdminRequest(delete_team, true);
 }
 
+// Reset the database
+function resetDatabase() {
+  var reset_database = {
+    action: 'reset_database'
+  };
+  sendAdminRequest(reset_database, true);
+}
+
 /**
  * submits an ajax request to the admin endpoint
  *
@@ -516,6 +524,14 @@ function exportCurrentCategories() {
   var action = 'export_categories';
   var url = 'index.php?p=admin&ajax=true&action=' + action + '&csrf_token=' + csrf_token;
   window.location.href = url;
+}
+
+// Flush Memcached
+function flushMemcached() {
+  var flush_memcached = {
+    action: 'flush_memcached'
+  };
+  sendAdminRequest(flush_memcached, true);
 }
 
 // Create tokens
@@ -1033,6 +1049,8 @@ module.exports = {
         importCategories();
       } else if (action === 'export-categories') {
         exportCurrentCategories();
+      } else if (action === 'flush-memcached') {
+        flushMemcached();
       } else if (action === 'create-tokens') {
         createTokens();
       } else if (action === 'export-tokens') {
@@ -1338,6 +1356,14 @@ module.exports = {
         $(this).text('Hide Answer');
         $(this).prev('input').attr('type', 'text');
       }
+    });
+
+    // prompt reset database
+    $('.js-reset-database').on('click', function(event) {
+      event.preventDefault();
+      Modal.loadPopup('p=action&modal=reset-database', 'action-reset-database', function() {
+        $('#reset_database').click(resetDatabase);
+      });
     });
 
   }


### PR DESCRIPTION
* Allow administrators to flush Memcached directly from the interface.  Flushing Memcached is required anytime data is manually manipulated within the database, additionally, if there is any caching issue, flushing Memcached is recommended.  The cache will rebuild after a flush without any additional action required by the user.

* Allow administrators to reset the database.  Resetting the database is useful when wanting to wipe all data from the application. Additionally, the process can be used to upgrade to the latest database schema.  Resetting the database will remove all current data (except admin users) and flush the data from the cache.  Administrative users will remain after a database reset.

* Added new "Utilities" line to the admin Control page.  Both the Flush Memcached and Reset Database buttons have been added to this section.

<img width="612" alt="screen shot 2017-01-27 at 12 27 56 pm" src="https://cloud.githubusercontent.com/assets/22864312/22380647/266025aa-e48c-11e6-9b88-acd137bf2ac0.png">

* The database reset button will prompt the user before resetting the database to ensure they understand the action will erase all existing data.

<img width="621" alt="screen shot 2017-01-27 at 12 28 06 pm" src="https://cloud.githubusercontent.com/assets/22864312/22380659/2eab76ce-e48c-11e6-9d81-8c8ef8e372a1.png">