### PR TITLE
Registration enforcing strong passwords

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -234,7 +234,7 @@ LOCK TABLES `password_types` WRITE;
 INSERT INTO `password_types` (field, value, description) VALUES("1", "/.+/", "Length > 0");
 INSERT INTO `password_types` (field, value, description) VALUES("2", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[0-9]).*$/", "Length > 8, [a-z] and [0-9]");
 INSERT INTO `password_types` (field, value, description) VALUES("3", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/", "Length > 8, [a-z], [A-Z] and [0-9]");
-INSERT INTO `password_types` (field, value, description) VALUES("4", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\W).*$/", "Length > 8, [a-z], [A-Z], [0-9] and Special chars");
+INSERT INTO `password_types` (field, value, description) VALUES("4", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[\\W]+).*$/", "Length > 8, [a-z], [A-Z], [0-9] and Special chars");
 
 UNLOCK TABLES;
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -207,7 +207,7 @@ INSERT INTO `configuration` (field, value, description) VALUES("ldap_domain_suff
 INSERT INTO `configuration` (field, value, description) VALUES("login", "1", "(Boolean) Ability to login");
 INSERT INTO `configuration` (field, value, description) VALUES("login_select", "0", "(Boolean) Login selecting the team");
 INSERT INTO `configuration` (field, value, description) VALUES("login_strongpasswords", "0", "(Boolean) Enforce using strong passwords");
-INSERT INTO `configuration` (field, value, description) VALUES("password_type", "1", "(Integer) Type of passwords: See password_types");
+INSERT INTO `configuration` (field, value, description) VALUES("password_type", "0", "(Integer) Type of passwords: See table password_types");
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonus", "30", "(Integer) Default value for bonus in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonusdec", "10", "(Integer) Default bonus decrement in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("language", "en", "(String) Language of the system");
@@ -223,17 +223,18 @@ DROP TABLE IF EXISTS `password_types`;
 CREATE TABLE `password_types` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `field` varchar(100) NOT NULL,
+  `value` text NOT NULL,
   `description` text NOT NULL,
-  `regex` text NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `field` (`field`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `password_types` WRITE;
-INSERT INTO `password_types` (field, regex, description) VALUES("1", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[0-9]).*$/", "Length > 8, [a-z] and [0-9]");
-INSERT INTO `password_types` (field, regex, description) VALUES("2", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/", "Length > 8, [a-z], [A-Z] and [0-9]");
-INSERT INTO `password_types` (field, regex, description) VALUES("3", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\W).*$/", "Length > 8, [a-z], [A-Z], [0-9] and Special chars");
+INSERT INTO `password_types` (field, value, description) VALUES("1", "/.+/", "Length > 0");
+INSERT INTO `password_types` (field, value, description) VALUES("2", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[0-9]).*$/", "Length > 8, [a-z] and [0-9]");
+INSERT INTO `password_types` (field, value, description) VALUES("3", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/", "Length > 8, [a-z], [A-Z] and [0-9]");
+INSERT INTO `password_types` (field, value, description) VALUES("4", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\W).*$/", "Length > 8, [a-z], [A-Z], [0-9] and Special chars");
 
 UNLOCK TABLES;
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -207,7 +207,7 @@ INSERT INTO `configuration` (field, value, description) VALUES("ldap_domain_suff
 INSERT INTO `configuration` (field, value, description) VALUES("login", "1", "(Boolean) Ability to login");
 INSERT INTO `configuration` (field, value, description) VALUES("login_select", "0", "(Boolean) Login selecting the team");
 INSERT INTO `configuration` (field, value, description) VALUES("login_strongpasswords", "0", "(Boolean) Enforce using strong passwords");
-INSERT INTO `configuration` (field, value, description) VALUES("password_type", "0", "(Integer) Type of passwords: See table password_types");
+INSERT INTO `configuration` (field, value, description) VALUES("password_type", "1", "(Integer) Type of passwords: See table password_types");
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonus", "30", "(Integer) Default value for bonus in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonusdec", "10", "(Integer) Default bonus decrement in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("language", "en", "(String) Language of the system");

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -118,11 +118,11 @@ CREATE TABLE `teams` (
   `active` tinyint(1) NOT NULL DEFAULT 1,
   `name` text NOT NULL,
   `password_hash` text NOT NULL,
-  `points` int(11) NOT NULL,
+  `points` int(11) NOT NULL DEFAULT 0,
   `last_score` timestamp NOT NULL,
   `logo` text NOT NULL,
-  `admin` tinyint(1) NOT NULL,
-  `protected` tinyint(1) NOT NULL,
+  `admin` tinyint(1) NOT NULL DEFAULT 0,
+  `protected` tinyint(1) NOT NULL DEFAULT 0,
   `visible` tinyint(1) NOT NULL DEFAULT 1,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
@@ -207,7 +207,7 @@ INSERT INTO `configuration` (field, value, description) VALUES("ldap_domain_suff
 INSERT INTO `configuration` (field, value, description) VALUES("login", "1", "(Boolean) Ability to login");
 INSERT INTO `configuration` (field, value, description) VALUES("login_select", "0", "(Boolean) Login selecting the team");
 INSERT INTO `configuration` (field, value, description) VALUES("login_strongpasswords", "0", "(Boolean) Enforce using strong passwords");
-INSERT INTO `configuration` (field, value, description) VALUES("password_type", "1", "(Integer) Type of passwords: See password_types");
+INSERT INTO `configuration` (field, value, description) VALUES("password_type", "1", "(Integer) Type of passwords: See table password_types");
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonus", "30", "(Integer) Default value for bonus in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonusdec", "10", "(Integer) Default bonus decrement in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("language", "en", "(String) Language of the system");
@@ -223,17 +223,18 @@ DROP TABLE IF EXISTS `password_types`;
 CREATE TABLE `password_types` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `field` varchar(100) NOT NULL,
+  `value` text NOT NULL,
   `description` text NOT NULL,
-  `regex` text NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `field` (`field`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `password_types` WRITE;
-INSERT INTO `password_types` (field, regex, description) VALUES("1", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[0-9]).*$/", "Length > 8, [a-z] and [0-9]");
-INSERT INTO `password_types` (field, regex, description) VALUES("2", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/", "Length > 8, [a-z], [A-Z] and [0-9]");
-INSERT INTO `password_types` (field, regex, description) VALUES("3", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*\W).*$/", "Length > 8, [a-z], [A-Z], [0-9] and Special chars");
+INSERT INTO `password_types` (field, value, description) VALUES("1", "/.+/", "Length > 0");
+INSERT INTO `password_types` (field, value, description) VALUES("2", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[0-9]).*$/", "Length > 8, [a-z] and [0-9]");
+INSERT INTO `password_types` (field, value, description) VALUES("3", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).*$/", "Length > 8, [a-z], [A-Z] and [0-9]");
+INSERT INTO `password_types` (field, value, description) VALUES("4", "/.*^(?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[\\W]+).*$/", "Length > 8, [a-z], [A-Z], [0-9] and Special chars");
 
 UNLOCK TABLES;
 

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -2887,7 +2887,8 @@ class AdminController extends Controller {
     if (count($failures) > 0) {
       $failures_tbody = <tbody></tbody>;
       foreach ($failures as $failure) {
-        if (!Level::genCheckStatus($failure->getLevelId())) {
+        $level_genCheckStatus = await Level::genCheckStatus($failure->getLevelId());
+        if (!$level_genCheckStatus) {
           continue;
         }
         $level = await Level::gen($failure->getLevelId());

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -149,6 +149,24 @@ class AdminController extends Controller {
     return $select;
   }
 
+  // TODO: Translate password types
+  private async function genStrongPasswordsSelect(): Awaitable<:xhp> {
+    $types = await Configuration::genPasswordTypes();
+    $select = <select name="fb--conf--password_type"></select>;
+    foreach ($types as $type) {
+      $select->appendChild(
+        <option 
+          class="fb--conf--password_type" 
+          value={strval($type->getField())}
+          selected={($type->getField() === $config)}>
+          {$type->getDescription()}
+        </option>
+      );
+    }
+
+    return $select;
+  }
+
   private async function genConfigurationDurationSelect(): Awaitable<:xhp> {
     $config = await Configuration::gen('game_duration_unit');
     $duration_unit = $config->getValue();
@@ -408,6 +426,7 @@ class AdminController extends Controller {
       'configuration_duration_select' =>
         $this->genConfigurationDurationSelect(),
       'language_select' => $this->genLanguageSelect(),
+      'password_types_select' => $this->genStrongPasswordsSelect(),
     };
     $results = await \HH\Asio\m($awaitables);
 
@@ -415,6 +434,18 @@ class AdminController extends Controller {
     $configuration_duration_select =
       $results['configuration_duration_select'];
     $language_select = $results['language_select'];
+    $password_types_select = $results['password_types_select'];
+
+    $login_strongpasswords = await Configuration::gen('login_strongpasswords');
+    if ($login_strongpasswords->getValue() === '0') { // Strong passwords are not enforced
+      $strong_passwords = <div></div>;
+    } else {
+      $strong_passwords =
+        <div class="form-el el--block-label">
+          <label>{tr('Password Types')}</label>
+          {$password_types_select}
+        </div>;
+    }
 
     return
       <div>
@@ -519,7 +550,32 @@ class AdminController extends Controller {
                   </div>
                 </header>
                 <div class="fb-column-container">
-                  <div class="col col-pad col-1-2">
+                  <div class="col col-pad col-1-3">
+                    <div class="form-el el--block-label">
+                      <label>{tr('Team Selection')}</label>
+                      <div class="admin-section-toggle radio-inline">
+                        <input
+                          type="radio"
+                          name="fb--conf--login_select"
+                          id="fb--conf--login_select--on"
+                          checked={$login_select_on}
+                        />
+                        <label for="fb--conf--login_select--on">
+                          {tr('On')}
+                        </label>
+                        <input
+                          type="radio"
+                          name="fb--conf--login_select"
+                          id="fb--conf--login_select--off"
+                          checked={$login_select_off}
+                        />
+                        <label for="fb--conf--login_select--off">
+                          {tr('Off')}
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col col-pad col-1-3">
                     <div class="form-el el--block-label">
                       <label>{tr('Strong Passwords')}</label>
                       <div class="admin-section-toggle radio-inline">
@@ -544,30 +600,8 @@ class AdminController extends Controller {
                       </div>
                     </div>
                   </div>
-                  <div class="col col-pad col-2-2">
-                    <div class="form-el el--block-label">
-                      <label>{tr('Team Selection')}</label>
-                      <div class="admin-section-toggle radio-inline">
-                        <input
-                          type="radio"
-                          name="fb--conf--login_select"
-                          id="fb--conf--login_select--on"
-                          checked={$login_select_on}
-                        />
-                        <label for="fb--conf--login_select--on">
-                          {tr('On')}
-                        </label>
-                        <input
-                          type="radio"
-                          name="fb--conf--login_select"
-                          id="fb--conf--login_select--off"
-                          checked={$login_select_off}
-                        />
-                        <label for="fb--conf--login_select--off">
-                          {tr('Off')}
-                        </label>
-                      </div>
-                    </div>
+                  <div class="col col-pad col-2-3">
+                    {$strong_passwords}
                   </div>
                 </div>
               </section>

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -151,14 +151,15 @@ class AdminController extends Controller {
 
   // TODO: Translate password types
   private async function genStrongPasswordsSelect(): Awaitable<:xhp> {
-    $types = await Configuration::genPasswordTypes();
+    $types = await Configuration::genAllPasswordTypes();
+    $config = await Configuration::genCurrentPasswordType();
     $select = <select name="fb--conf--password_type"></select>;
     foreach ($types as $type) {
       $select->appendChild(
         <option 
           class="fb--conf--password_type" 
           value={strval($type->getField())}
-          selected={($type->getField() === $config)}>
+          selected={($type->getField() === $config->getField())}>
           {$type->getDescription()}
         </option>
       );

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -470,7 +470,7 @@ class IndexController extends Controller {
               <h6>{tr('Choose an Emblem')}</h6>
               <h6>
                 <a href="#" id="custom-emblem-link">
-                  {tr('or Upload your own')}
+                  {tr('or upload your own')}
                 </a>
               </h6>
               <div class="custom-emblem">

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -345,6 +345,7 @@ class IndexController extends Controller {
                   name="teamname"
                   type="text"
                   maxlength={20}
+                  autofocus={true}
                 />
                 {$ldap_domain_suffix}
               </div>
@@ -451,6 +452,7 @@ class IndexController extends Controller {
                   name="teamname"
                   type="text"
                   maxlength={20}
+                  autofocus={true}
                 />
                 {$ldap_domain_suffix}
               </div>
@@ -458,13 +460,17 @@ class IndexController extends Controller {
                 <label for="">{tr('Password')}</label>
                 <input autocomplete="off" name="password" type="password" />
               </div>
+              <div id="password_error" class="el--text completely-hidden">
+                <label for=""></label>
+                <h6 style="color:red;">{tr('Password is too simple')}</h6>
+              </div>
               {$token_field}
             </fieldset>
             <div class="fb-choose-emblem">
               <h6>{tr('Choose an Emblem')}</h6>
               <h6>
                 <a href="#" id="custom-emblem-link">
-                  {tr('or upload your own')}
+                  {tr('or Upload your own')}
                 </a>
               </h6>
               <div class="custom-emblem">

--- a/src/controllers/ajax/IndexAjaxController.php
+++ b/src/controllers/ajax/IndexAjaxController.php
@@ -115,6 +115,15 @@ class IndexAjaxController extends AjaxController {
       return Utils::error_response('Registration failed', 'registration');
     }
 
+    // Check if strongs passwords are enforced
+    $login_strongpasswords = await Configuration::gen('login_strongpasswords');
+    if ($login_strongpasswords->getValue() !== '0') {
+      $password_type = await Configuration::genCurrentPasswordType();
+      if (!preg_match(strval($password_type->getValue()), $password)) {
+        return Utils::error_response('Password too simple', 'registration');
+      }
+    }
+
     // Check if ldap is enabled and verify credentials if successful
     $ldap = await Configuration::gen('ldap');
     if ($ldap->getValue() === '1') {

--- a/src/controllers/ajax/IndexAjaxController.php
+++ b/src/controllers/ajax/IndexAjaxController.php
@@ -126,6 +126,7 @@ class IndexAjaxController extends AjaxController {
 
     // Check if ldap is enabled and verify credentials if successful
     $ldap = await Configuration::gen('ldap');
+    $ldap_password = '';
     if ($ldap->getValue() === '1') {
       // Get server information from configuration
       $ldap_server = await Configuration::gen('ldap_server');
@@ -154,10 +155,10 @@ class IndexAjaxController extends AjaxController {
       // This will help avoid leaking users ldap passwords if the server's database
       // is compromised.
       $ldap_password = $password;
-      $password = gmp_strval(
+      $password = strval(gmp_strval(
         gmp_init(bin2hex(openssl_random_pseudo_bytes(16)), 16),
         62,
-      );
+      ));
     }
 
     // Check if tokenized registration is enabled
@@ -214,9 +215,11 @@ class IndexAjaxController extends AjaxController {
           await Token::genUse($token, $team_id);
         }
         // Login the team
-        if ($ldap->getValue() === '1')
-          return await $this->genLoginTeam($team_id, $ldap_password); else
+        if ($ldap->getValue() === '1') {
+          return await $this->genLoginTeam($team_id, $ldap_password); 
+        } else {
           return await $this->genLoginTeam($team_id, $password);
+        }
       } else {
         return Utils::error_response('Registration failed', 'registration');
       }

--- a/src/language/lang_en.php
+++ b/src/language/lang_en.php
@@ -85,6 +85,12 @@ $translations = array(
     'Password',
   'Choose an Emblem' =>
     'Choose an Emblem',
+  'or Upload your own' =>
+    'or Upload your own',
+  'Clear your custom emblem to use a default emblem.' =>
+    'Clear your custom emblem to use a default emblem.',
+  'Password is too simple' =>
+    'Password is too simple',
   'Sign Up' =>
     'Sign Up',
   'Register to play Capture The Flag here. Once you have registered, you will be logged in.' =>

--- a/src/models/Configuration.php
+++ b/src/models/Configuration.php
@@ -78,6 +78,20 @@ class Configuration extends Model {
     return intval(idx(firstx($result->mapRows()), 'COUNT(*)')) > 0;
   }
 
+  // All the password types.
+  public static async function genPasswordTypes(
+  ): Awaitable<array<Configuration>> {
+    $db = await self::genDb();
+    $result = await $db->queryf('SELECT * FROM password_types');
+
+    $types = array();
+    foreach ($result->mapRows() as $row) {
+      $types[] = self::configurationFromRow($row->toArray());
+    }
+
+    return $types;
+  }
+
   // All the configuration.
   public static async function genAllConfiguration(
   ): Awaitable<array<Configuration>> {

--- a/src/models/Configuration.php
+++ b/src/models/Configuration.php
@@ -79,7 +79,7 @@ class Configuration extends Model {
   }
 
   // All the password types.
-  public static async function genPasswordTypes(
+  public static async function genAllPasswordTypes(
   ): Awaitable<array<Configuration>> {
     $db = await self::genDb();
     $result = await $db->queryf('SELECT * FROM password_types');
@@ -90,6 +90,21 @@ class Configuration extends Model {
     }
 
     return $types;
+  }
+
+  // Current password type.
+  public static async function genCurrentPasswordType(
+  ): Awaitable<Configuration> {
+    $db = await self::genDb();
+    $db_result = await $db->queryf(
+      'SELECT * FROM password_types WHERE field = (SELECT value FROM configuration WHERE field = %s) LIMIT 1',
+      'password_type'
+    );
+
+    invariant($db_result->numRows() === 1, 'Expected exactly one result');
+    $result = firstx($db_result->mapRows())->toArray();
+
+    return self::configurationFromRow($result);
   }
 
   // All the configuration.

--- a/src/models/Logo.php
+++ b/src/models/Logo.php
@@ -269,6 +269,8 @@ class Logo extends Model implements Importable, Exportable {
     // Get image properties and verify mimetype
     $base64_data = str_replace(' ', '+', $base64_data);
     $binary_data = base64_decode(str_replace(' ', '+', $base64_data));
+    /* HH_IGNORE_ERROR[2049] */
+    /* HH_IGNORE_ERROR[4107] */
     $image_info = getimagesizefromstring($binary_data);
 
     $mimetype = $image_info[2];

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -909,7 +909,10 @@ function toggleConfiguration(radio_id) {
     field: radio_action,
     value: action_value
   };
-  if (radio_action) {
+  var refresh_fields = ['login_strongpasswords'];
+  if (refresh_fields.indexOf(radio_action) !== -1) {
+    sendAdminRequest(toggle_data, true);
+  } else {
     sendAdminRequest(toggle_data, false);
   }
 }
@@ -920,9 +923,10 @@ function changeConfiguration(field, value) {
     field: field,
     value: value
   };
-  if (field === 'registration_type' || field === 'language') {
+  var refresh_fields = ['registration_type', 'language'];
+  if (refresh_fields.indexOf(field) !== -1) {
     sendAdminRequest(conf_data, true);
-  }else {
+  } else {
     sendAdminRequest(conf_data, false);
   }
 }

--- a/src/static/js/index.js
+++ b/src/static/js/index.js
@@ -7,10 +7,16 @@ function teamNameFormError() {
   });
 }
 
-function teamPasswordFormError() {
+function teamPasswordFormError(toosimple) {
   $('.el--text')[1].classList.add('form-error');
+  if (toosimple) {
+    $('#password_error')[0].classList.remove('completely-hidden');
+  }
   $('.fb-form input[name="password"]').on('change', function() {
     $('.el--text')[1].classList.remove('form-error');
+    if (toosimple) {
+      $('#password_error')[0].classList.add('completely-hidden');
+    }
   });
 }
 
@@ -109,9 +115,10 @@ function sendIndexRequest(request_data) {
       goToPage(responseData.redirect);
     } else {
       // TODO: Make this a modal
-      console.log('Failed');
-      teamNameFormError();
-      teamPasswordFormError();
+      verifyTeamName('register');
+      if (responseData.message === 'Password too simple') {
+        teamPasswordFormError(true);
+      }
       teamTokenFormError();
     }
   });

--- a/src/xhp/Fbbranding.php
+++ b/src/xhp/Fbbranding.php
@@ -11,7 +11,7 @@ class :fbbranding extends :x:element {
         <svg class="icon icon--social-facebook">
           <use href="#icon--social-facebook" />
         </svg>
-        <span class="has-icon">{tr('Powered By Facebook')}</span>
+        <span class="has-icon">{' '}{tr('Powered By Facebook')}</span>
       </span>;
   }
 }

--- a/tests/models/PasswordTypesTest.php
+++ b/tests/models/PasswordTypesTest.php
@@ -1,0 +1,21 @@
+<?hh
+
+class PasswordTypesTest extends FBCTFTest {
+
+  public function testAll(): void {
+    $all = HH\Asio\join(Configuration::genAllPasswordTypes());
+    $this->assertEquals(4, count($all));
+
+    $p = $all[0];
+    $this->assertTrue((bool)preg_match($p->getValue(), 'a'));
+
+    $p = $all[1];
+    $this->assertTrue((bool)preg_match($p->getValue(), 'password1'));
+
+    $p = $all[2];
+    $this->assertTrue((bool)preg_match($p->getValue(), 'Password1'));
+
+    $p = $all[3];
+    $this->assertTrue((bool)preg_match($p->getValue(), 'Pas$word1'));
+  }
+}


### PR DESCRIPTION
Strongs passwords now can be enforced, with a configuration radio button and a dropdown select to pick how strong the password will be:

![image](https://cloud.githubusercontent.com/assets/1271349/22609180/064e5500-ea15-11e6-82e5-2c1eecd28e9c.png)

The registration window will look like this when the chosen password is not strong enough:

![image](https://cloud.githubusercontent.com/assets/1271349/22609183/0d61c1a6-ea15-11e6-9000-e0fa94447960.png)
