### PR TITLE
Custom branding for icon and text

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -211,6 +211,9 @@ INSERT INTO `configuration` (field, value, description) VALUES("password_type", 
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonus", "30", "(Integer) Default value for bonus in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("default_bonusdec", "10", "(Integer) Default bonus decrement in levels");
 INSERT INTO `configuration` (field, value, description) VALUES("language", "en", "(String) Language of the system");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_logo", "0", "(Boolean) Custom branding logo");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_text", "Powered By Facebook", "(String) Custom branding text");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_logo_image", "static/img/favicon.png", "(String) Custom logo image file");
 UNLOCK TABLES;
 
 --

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -311,6 +311,9 @@ class AdminController extends Controller {
       'bases_cycle' => Configuration::gen('bases_cycle'),
       'start_ts' => Configuration::gen('start_ts'),
       'end_ts' => Configuration::gen('end_ts'),
+      'custom_logo' => Configuration::gen('custom_logo'),
+      'custom_text' => Configuration::gen('custom_text'),
+      'custom_logo_image' => Configuration::gen('custom_logo_image'),
     };
 
     $results = await \HH\Asio\m($awaitables);
@@ -335,6 +338,9 @@ class AdminController extends Controller {
     $bases_cycle = $results['bases_cycle'];
     $start_ts = $results['start_ts'];
     $end_ts = $results['end_ts'];
+    $custom_logo = $results['custom_logo'];
+    $custom_text = $results['custom_text'];
+    $custom_logo_image = $results['custom_logo_image'];
 
     $registration_on = $registration->getValue() === '1';
     $registration_off = $registration->getValue() === '0';
@@ -354,6 +360,8 @@ class AdminController extends Controller {
     $gameboard_off = $gameboard->getValue() === '0';
     $timer_on = $timer->getValue() === '1';
     $timer_off = $timer->getValue() === '0';
+    $custom_logo_on = $custom_logo->getValue() === '1';
+    $custom_logo_off = $custom_logo->getValue() === '0';
 
     $game_start_array = array();
     if ($start_ts->getValue() !== '0' && $start_ts->getValue() !== 'NaN') {
@@ -437,7 +445,6 @@ class AdminController extends Controller {
     $language_select = $results['language_select'];
     $password_types_select = $results['password_types_select'];
 
-    $login_strongpasswords = await Configuration::gen('login_strongpasswords');
     if ($login_strongpasswords->getValue() === '0') { // Strong passwords are not enforced
       $strong_passwords = <div></div>;
     } else {
@@ -445,6 +452,33 @@ class AdminController extends Controller {
         <div class="form-el el--block-label">
           <label>{tr('Password Types')}</label>
           {$password_types_select}
+        </div>;
+    }
+
+    if ($custom_logo->getValue() === '0') { // Custom branding is not enabled
+      $custom_logo_xhp = <div></div>;
+    } else {
+      $custom_logo_xhp =
+        <div class="form-el el--block-label el--full-text">
+          <label for="">{tr('Logo')}</label>
+          <img 
+            id="custom-logo-image" 
+            class="icon--badge" 
+            src={$custom_logo_image->getValue()}
+          />
+          <br/>
+           <h6>
+            <a class="icon-text" href="#" id="custom-logo-link">
+            {tr('Change')}
+            </a>
+          </h6>
+          <input
+            autocomplete="off"
+            name="custom-logo-input"
+            id="custom-logo-input"
+            type="file"
+            accept="image/*"
+          />
         </div>;
     }
 
@@ -914,11 +948,59 @@ class AdminController extends Controller {
               </section>
               <section class="admin-box">
                 <header class="admin-box-header">
-                  <h3>{tr('Language')}</h3>
+                  <h3>{tr('Internationalization')}</h3>
                 </header>
-                <div class="col col-pad col-1-2">
-                  <div class="form-el el--block-label el--full-text">
-                    {$language_select}
+                <div class="fb-column-container">
+                  <div class="col col-pad col-2-4">
+                    <div class="form-el el--block-label">
+                      <label for="">{tr('Language')}</label>
+                      {$language_select}
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section class="admin-box">
+                <header class="admin-box-header">
+                  <h3>{tr('Branding')}</h3>
+                </header>
+                <div class="fb-column-container">
+                  <div class="col col-pad col-1-3">
+                    <div class="form-el el--block-label">
+                      <label>{tr('Custom Logo')}</label>
+                      <div class="admin-section-toggle radio-inline">
+                        <input
+                          type="radio"
+                          name="fb--conf--custom_logo"
+                          id="fb--conf--custom_logo--on"
+                          checked={$custom_logo_on}
+                        />
+                        <label for="fb--conf--custom_logo--on">
+                          {tr('On')}
+                        </label>
+                        <input
+                          type="radio"
+                          name="fb--conf--custom_logo"
+                          id="fb--conf--custom_logo--off"
+                          checked={$custom_logo_off}
+                        />
+                        <label for="fb--conf--custom_logo--off">
+                          {tr('Off')}
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="col col-pad col-1-3">
+                    {$custom_logo_xhp}
+                  </div>
+                  <div class="col col-pad col-1-3">
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Custom Text')}</label>
+                      <input
+                        type="text"
+                        name="fb--conf--custom_text"
+                        value={$custom_text->getValue()}
+                      />
+                    </div>
                   </div>
                 </div>
               </section>
@@ -3718,6 +3800,13 @@ class AdminController extends Controller {
           {tr('Begin Game')}
         </a>;
     }
+    $custom_logo = await Configuration::gen('custom_logo');
+    $branding_fb = $custom_logo->getValue() === '0';
+    if ($branding_fb) {
+      $branding_xhp = <fbbranding />;
+    } else {
+      $branding_xhp = <custombranding />;
+    }
     return
       <div id="fb-admin-nav" class="admin-nav-bar fb-row-container">
         <header class="admin-nav-header row-fixed">
@@ -3790,7 +3879,7 @@ class AdminController extends Controller {
           <a href="/index.php?p=game">{tr('Gameboard')}</a>
           <a href="" class="js-prompt-logout">{tr('Logout')}</a>
           <a></a>
-          <fbbranding />
+          {$branding_xhp}
         </div>
       </div>;
   }

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -3800,13 +3800,7 @@ class AdminController extends Controller {
           {tr('Begin Game')}
         </a>;
     }
-    $custom_logo = await Configuration::gen('custom_logo');
-    $branding_fb = $custom_logo->getValue() === '0';
-    if ($branding_fb) {
-      $branding_xhp = <fbbranding />;
-    } else {
-      $branding_xhp = <custombranding />;
-    }
+    $branding_xhp = await $this->genRenderBranding();
     return
       <div id="fb-admin-nav" class="admin-nav-bar fb-row-container">
         <header class="admin-nav-header row-fixed">

--- a/src/controllers/Controller.php
+++ b/src/controllers/Controller.php
@@ -7,6 +7,25 @@ abstract class Controller {
 
   abstract protected function genRenderBody(string $page): Awaitable<:xhp>;
 
+  public async function genRenderBranding(): Awaitable<:xhp> {
+    $branding = await Configuration::gen('custom_logo');
+    $custom_text = await Configuration::gen('custom_text');
+    if ($branding->getValue() === '0') {
+      $branding_xhp = 
+        <fbbranding
+          brandingText={tr(strval($custom_text->getValue()))}
+        />;
+    } else {
+      $custom_logo_image = await Configuration::gen('custom_logo_image');
+      $branding_xhp = 
+        <custombranding
+          brandingText={strval($custom_text->getValue())}
+          brandingLogo={strval($custom_logo_image->getValue())}
+        />;
+    }
+    return $branding_xhp;
+  }
+
   public async function genRender(): Awaitable<:xhp> {
     $page = $this->processRequest();
     $body = await $this->genRenderBody($page);

--- a/src/controllers/Controller.php
+++ b/src/controllers/Controller.php
@@ -8,15 +8,21 @@ abstract class Controller {
   abstract protected function genRenderBody(string $page): Awaitable<:xhp>;
 
   public async function genRenderBranding(): Awaitable<:xhp> {
-    $branding = await Configuration::gen('custom_logo');
-    $custom_text = await Configuration::gen('custom_text');
+    $awaitables = Map {
+      'custom_logo' => Configuration::gen('custom_logo'),
+      'custom_text' => Configuration::gen('custom_text'),
+      'custom_logo_image' => Configuration::gen('custom_logo_image'),
+    };
+    $results = await \HH\Asio\m($awaitables);
+    $branding = $results['custom_logo'];
+    $custom_text = $results['custom_text'];
     if ($branding->getValue() === '0') {
       $branding_xhp = 
         <fbbranding
           brandingText={tr(strval($custom_text->getValue()))}
         />;
     } else {
-      $custom_logo_image = await Configuration::gen('custom_logo_image');
+      $custom_logo_image = $results['custom_logo_image'];
       $branding_xhp = 
         <custombranding
           brandingText={strval($custom_text->getValue())}

--- a/src/controllers/GameboardController.php
+++ b/src/controllers/GameboardController.php
@@ -23,12 +23,24 @@ class GameboardController extends Controller {
     return array('main', 'viewmode');
   }
 
-  public function renderMainContent(): :xhp {
+  public async function genRenderBranding(): Awaitable<:xhp> {
+    $branding = await Configuration::gen('custom_logo');
+    $branding_fb = $branding->getValue() === '0';
+    if ($branding_fb) {
+      $branding_xhp = <fbbranding />;
+    } else {
+      $branding_xhp = <custombranding />;
+    }
+    return $branding_xhp;
+  }
+
+  public async function genRenderMainContent(): Awaitable<:xhp> {
     if (SessionUtils::sessionAdmin()) {
       $admin_link = <li><a href="index.php?p=admin">{tr('Admin')}</a></li>;
     } else {
       $admin_link = null;
     }
+    $branding_gen = await $this->genRenderBranding();
     return
       <div id="fb-gameboard" class="fb-gameboard">
         <div class="gameboard-header">
@@ -58,7 +70,7 @@ class GameboardController extends Controller {
             <div class="branding">
               <a href="index.php?p=game">
                 <div class="branding-rules">
-                  <fbbranding />
+                  {$branding_gen}
                 </div>
               </a>
             </div>
@@ -137,19 +149,20 @@ class GameboardController extends Controller {
       </div>;
   }
 
-  public function renderPage(string $page): :xhp {
+  public async function genRenderPage(string $page): Awaitable<:xhp> {
     switch ($page) {
       case 'main':
-        return $this->renderMainContent();
+        return await $this->genRenderMainContent();
         break;
       default:
-        return $this->renderMainContent();
+        return await $this->genRenderMainContent();
         break;
     }
   }
 
   <<__Override>>
   public async function genRenderBody(string $page): Awaitable<:xhp> {
+    $rendered_page = await $this->genRenderPage($page);
     return
       <body data-section="gameboard">
         <input
@@ -159,7 +172,7 @@ class GameboardController extends Controller {
         />
         <div class="fb-sprite" id="fb-svg-sprite"></div>
         <div id="fb-main-content" class="fb-page">
-          {$this->renderPage($page)}
+          {$rendered_page}
         </div>
         <script type="text/javascript" src="static/dist/js/app.js"></script>
       </body>;

--- a/src/controllers/GameboardController.php
+++ b/src/controllers/GameboardController.php
@@ -23,17 +23,6 @@ class GameboardController extends Controller {
     return array('main', 'viewmode');
   }
 
-  public async function genRenderBranding(): Awaitable<:xhp> {
-    $branding = await Configuration::gen('custom_logo');
-    $branding_fb = $branding->getValue() === '0';
-    if ($branding_fb) {
-      $branding_xhp = <fbbranding />;
-    } else {
-      $branding_xhp = <custombranding />;
-    }
-    return $branding_xhp;
-  }
-
   public async function genRenderMainContent(): Awaitable<:xhp> {
     if (SessionUtils::sessionAdmin()) {
       $admin_link = <li><a href="index.php?p=admin">{tr('Admin')}</a></li>;

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -733,21 +733,7 @@ class IndexController extends Controller {
   }
 
   public async function genRenderMobilePage(): Awaitable<:xhp> {
-    $branding = await Configuration::gen('custom_logo');
-    $custom_text = await Configuration::gen('custom_text');
-    if ($branding->getValue() === '0') {
-      $branding_xhp = 
-        <fbbranding
-          brandingText={tr(strval($custom_text->getValue()))}
-        />;
-    } else {
-      $custom_logo_image = await Configuration::gen('custom_logo_image');
-      $branding_xhp = 
-        <custombranding
-          brandingText={strval($custom_text->getValue())}
-          brandingLogo={strval($custom_logo_image->getValue())}
-        />;
-    }
+    $branding_xhp = await $this->genRenderBranding();
     return
       <div class="fb-row-container full-height page--mobile">
         <main

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -732,24 +732,21 @@ class IndexController extends Controller {
       </main>;
   }
 
-  public async function genRenderBranding(): Awaitable<:xhp> {
-    $branding = await Configuration::gen('custom_logo');
-    $branding_fb = $branding->getValue() === '0';
-    if ($branding_fb) {
-      $branding_xhp = <fbbranding />;
-    } else {
-      $branding_xhp = <custombranding />;
-    }
-    return $branding_xhp;
-  }
-
   public async function genRenderMobilePage(): Awaitable<:xhp> {
     $branding = await Configuration::gen('custom_logo');
-    $branding_fb = $branding->getValue() === '0';
-    if ($branding_fb) {
-      $branding_xhp = <fbbranding />;
+    $custom_text = await Configuration::gen('custom_text');
+    if ($branding->getValue() === '0') {
+      $branding_xhp = 
+        <fbbranding
+          brandingText={tr(strval($custom_text->getValue()))}
+        />;
     } else {
-      $branding_xhp = <custombranding />;
+      $custom_logo_image = await Configuration::gen('custom_logo_image');
+      $branding_xhp = 
+        <custombranding
+          brandingText={strval($custom_text->getValue())}
+          brandingLogo={strval($custom_logo_image->getValue())}
+        />;
     }
     return
       <div class="fb-row-container full-height page--mobile">

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -732,7 +732,25 @@ class IndexController extends Controller {
       </main>;
   }
 
-  public function renderMobilePage(): :xhp {
+  public async function genRenderBranding(): Awaitable<:xhp> {
+    $branding = await Configuration::gen('custom_logo');
+    $branding_fb = $branding->getValue() === '0';
+    if ($branding_fb) {
+      $branding_xhp = <fbbranding />;
+    } else {
+      $branding_xhp = <custombranding />;
+    }
+    return $branding_xhp;
+  }
+
+  public async function genRenderMobilePage(): Awaitable<:xhp> {
+    $branding = await Configuration::gen('custom_logo');
+    $branding_fb = $branding->getValue() === '0';
+    if ($branding_fb) {
+      $branding_xhp = <fbbranding />;
+    } else {
+      $branding_xhp = <custombranding />;
+    }
     return
       <div class="fb-row-container full-height page--mobile">
         <main
@@ -751,12 +769,12 @@ class IndexController extends Controller {
           </div>
         </main>
         <div class="row-fixed">
-          <fbbranding />
+          {$branding_xhp}
         </div>
       </div>;
   }
 
-  public function renderMainNav(): :xhp {
+  public async function genRenderMainNav(): Awaitable<:xhp> {
     if (SessionUtils::sessionActive()) {
       $right_nav =
         <ul class="nav-right">
@@ -804,17 +822,20 @@ class IndexController extends Controller {
           </a>
         </li>
       </ul>;
+    $branding_gen = await $this->genRenderBranding();
+    $branding = 
+      <div class="branding">
+        <a href="/">
+          <div class="branding-rules">
+            {$branding_gen}
+          </div>
+        </a>
+      </div>;
 
     return
       <nav class="fb-main-nav fb-navigation">
         {$left_nav}
-        <div class="branding">
-          <a href="/">
-            <div class="branding-rules">
-              <fbbranding />
-            </div>
-          </a>
-        </div>
+        {$branding}
         {$right_nav}
       </nav>;
   }
@@ -826,7 +847,7 @@ class IndexController extends Controller {
       case 'error':
         return $this->renderErrorPage();
       case 'mobile':
-        return $this->renderMobilePage();
+        return await $this->genRenderMobilePage();
       case 'login':
         return await $this->genRenderLoginContent();
       case 'registration':
@@ -847,11 +868,12 @@ class IndexController extends Controller {
   <<__Override>>
   public async function genRenderBody(string $page): Awaitable<:xhp> {
     $rendered_page = await $this->genRenderPage($page);
+    $rendered_nav = await $this->genRenderMainNav();
     return
       <body data-section="pages">
         <div class="fb-sprite" id="fb-svg-sprite"></div>
         <div class="fb-viewport">
-          <div id="fb-main-nav">{$this->renderMainNav()}</div>
+          <div id="fb-main-nav">{$rendered_nav}</div>
           <div id="fb-main-content" class="fb-page">{$rendered_page}</div>
         </div>
         <script type="text/javascript" src="static/dist/js/app.js"></script>

--- a/src/controllers/ViewModeController.php
+++ b/src/controllers/ViewModeController.php
@@ -23,17 +23,6 @@ class ViewModeController extends Controller {
     return array('main');
   }
 
-  public async function genRenderBranding(): Awaitable<:xhp> {
-    $branding = await Configuration::gen('custom_logo');
-    $branding_fb = $branding->getValue() === '0';
-    if ($branding_fb) {
-      $branding_xhp = <fbbranding />;
-    } else {
-      $branding_xhp = <custombranding />;
-    }
-    return $branding_xhp;
-  }
-
   public async function genRenderMainContent(): Awaitable<:xhp> {
     $branding_gen = await $this->genRenderBranding();
     return

--- a/src/controllers/ajax/AdminAjaxController.php
+++ b/src/controllers/ajax/AdminAjaxController.php
@@ -29,6 +29,10 @@ class AdminAjaxController extends AjaxController {
           'filter' => FILTER_VALIDATE_REGEXP,
           'options' => array('regexp' => '/^[\w-]+$/'),
         ),
+        'logo_b64' => array(
+          'filter' => FILTER_VALIDATE_REGEXP,
+          'options' => array('regexp' => '/^[\w+-\/]+={0,2}$/'),
+        ),
         'entity_id' => FILTER_VALIDATE_INT,
         'attachment_id' => FILTER_VALIDATE_INT,
         'filename' => array(
@@ -117,6 +121,7 @@ class AdminAjaxController extends AjaxController {
       'delete_link',
       'begin_game',
       'change_configuration',
+      'change_custom_logo',
       'create_announcement',
       'delete_announcement',
       'create_tokens',
@@ -403,6 +408,14 @@ class AdminAjaxController extends AjaxController {
           return Utils::ok_response('Success', 'admin');
         } else {
           return Utils::error_response('Invalid configuration', 'admin');
+        }
+      case 'change_custom_logo':
+        $logo = must_have_string($params, 'logo_b64');
+        $custom_logo = await Logo::genCreateCustom($logo, true);
+        if ($custom_logo) {
+          return Utils::ok_response('Success', 'admin');
+        } else {
+          return Utils::error_response('Error changing logo', 'admin');
         }
       case 'create_announcement':
         await Announcement::genCreate(

--- a/src/language/lang_en.php
+++ b/src/language/lang_en.php
@@ -85,8 +85,8 @@ $translations = array(
     'Password',
   'Choose an Emblem' =>
     'Choose an Emblem',
-  'or Upload your own' =>
-    'or Upload your own',
+  'or upload your own' =>
+    'or upload your own',
   'Clear your custom emblem to use a default emblem.' =>
     'Clear your custom emblem to use a default emblem.',
   'Password is too simple' =>
@@ -235,8 +235,18 @@ $translations = array(
     'Begin Time',
   'Expected End Time' =>
     'Expected End Time',
+  'Internationalization' =>
+    'Internationalization',
   'Language' =>
     'Language',
+  'Branding' =>
+    'Branding',
+  'Custom Logo' =>
+    'Custom Logo',
+  'Logo' =>
+    'Logo',
+  'Custom Text' =>
+    'Custom Text',
   'DELETE' =>
     'DELETE',
   'Delete' =>

--- a/src/language/lang_es.php
+++ b/src/language/lang_es.php
@@ -229,8 +229,18 @@ $translations = array(
     'Tiempo de Inicio',
   'Expected End Time' =>
     'Tiempo de Finalización Esperada',
+  'Internationalization' =>
+    'Internacionalización',
   'Language' =>
-    'Lenguaje',
+    'Idioma',
+  'Branding' =>
+    'Personalización',
+  'Custom Logo' =>
+    'Logo Personalizado',
+  'Logo' =>
+    'Logo',
+  'Custom Text' =>
+    'Texto Personalizado',
   'DELETE' =>
     'BORRAR',
   'Delete' =>

--- a/src/models/Logo.php
+++ b/src/models/Logo.php
@@ -252,6 +252,7 @@ class Logo extends Model implements Importable, Exportable {
   // Create custom logo
   public static async function genCreateCustom(
     string $base64_data,
+    bool $branding = false,
   ): Awaitable<?Logo> {
     // Check image size
     $image_size_bytes = strlen($base64_data) * self::BASE64_BYTES_PER_CHAR;
@@ -297,8 +298,6 @@ class Logo extends Model implements Importable, Exportable {
       );
     }
 
-    $db = await self::genDb();
-
     $used = true;
     $enabled = true;
     $protected = false;
@@ -311,6 +310,11 @@ class Logo extends Model implements Importable, Exportable {
       $filename,
       $filepath,
     );
+
+    // If created logo is for branding, set configuration value
+    if ($branding) {
+      await Configuration::genUpdate('custom_logo_image', $logo->getLogo());
+    }
 
     // Return newly created logo_id
     return $logo;

--- a/src/static/css/scss/_admin.scss
+++ b/src/static/css/scss/_admin.scss
@@ -139,6 +139,10 @@ General Admin
     }
   }
 
+  #custom-logo-input {
+    display: none;
+  }
+
   input:not(:checked) + label {
     color: $teal-blue;
   }

--- a/src/static/css/scss/_icons.scss
+++ b/src/static/css/scss/_icons.scss
@@ -9,6 +9,10 @@
   vertical-align: middle;
 }
 
+.icon-text {
+  vertical-align: middle;
+}
+
 .has-icon {
   vertical-align: middle;
 }

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -909,7 +909,7 @@ function toggleConfiguration(radio_id) {
     field: radio_action,
     value: action_value
   };
-  var refresh_fields = ['login_strongpasswords'];
+  var refresh_fields = ['login_strongpasswords', 'custom_logo'];
   if (refresh_fields.indexOf(radio_action) !== -1) {
     sendAdminRequest(toggle_data, true);
   } else {
@@ -1391,6 +1391,43 @@ module.exports = {
       Modal.loadPopup('p=action&modal=reset-database', 'action-reset-database', function() {
         $('#reset_database').click(resetDatabase);
       });
+    });
+
+    // custom logo file selector
+    var $customLogoInput = $('#custom-logo-input');
+    var $customLogoImage = $('#custom-logo-image');
+    $('#custom-logo-link').on('click', function() {
+      $customLogoInput.trigger('click');
+    });
+    // on file input change, set image
+    $customLogoInput.change(function() {
+      var input = this;
+      if (input.files && input.files[0]) {
+        if (input.files[0].size > (1000*1024)) {
+          alert('Please upload an image less than 1000KB!');
+          return;
+        }
+
+        var reader = new FileReader();
+
+        reader.onload = function (e) {
+          $customLogoImage.attr('src', e.target.result);
+          var rawImageData = e.target.result;
+          var filetypeBeginIdx = rawImageData.indexOf('/') + 1;
+          var filetypeEndIdx = rawImageData.indexOf(';');
+          var filetype = rawImageData.substring(filetypeBeginIdx, filetypeEndIdx);
+          var base64 = rawImageData.substring(rawImageData.indexOf(',') + 1);
+          var logo_data = {
+            action: 'change_custom_logo',
+            logoType: filetype,
+            logo_b64: base64
+          };
+          sendAdminRequest(logo_data, true);
+        };
+
+        reader.readAsDataURL(input.files[0]);
+
+      }
     });
 
   }

--- a/src/static/js/fb-ctf.js
+++ b/src/static/js/fb-ctf.js
@@ -2511,7 +2511,6 @@ function setupInputListeners() {
     });
     // on file input change, set image preview and emblem carousel notice
     $customEmblemInput.change(function() {
-console.log('foo');
       var input = this;
       if (input.files && input.files[0]) {
         if (input.files[0].size > (1000*1024)) {

--- a/src/xhp/Custombranding.php
+++ b/src/xhp/Custombranding.php
@@ -2,17 +2,18 @@
 
 class :custombranding extends :x:element {
   category %flow;
+  attribute
+    string brandingText,
+    string brandingLogo;
 
   protected string $tagName = 'custombranding';
 
   protected function render(): XHPRoot {
-    $custom_text = \HH\Asio\join(Configuration::gen('custom_text'));
-    $custom_image = \HH\Asio\join(Configuration::gen('custom_logo_image'));
     return
       <span class="branding-el">
-        <img class="icon-badge" src={strval($custom_image->getValue())}/>
+        <img class="icon-badge" src={$this->:brandingLogo}/>
         <br/>
-        <span class="icon-text">{tr(strval($custom_text->getValue()))}</span>
+        <span class="icon-text">{$this->:brandingText}</span>
       </span>;
   }
 }

--- a/src/xhp/Custombranding.php
+++ b/src/xhp/Custombranding.php
@@ -1,0 +1,18 @@
+<?hh // strict
+
+class :custombranding extends :x:element {
+  category %flow;
+
+  protected string $tagName = 'custombranding';
+
+  protected function render(): XHPRoot {
+    $custom_text = \HH\Asio\join(Configuration::gen('custom_text'));
+    $custom_image = \HH\Asio\join(Configuration::gen('custom_logo_image'));
+    return
+      <span class="branding-el">
+        <img class="icon-badge" src={strval($custom_image->getValue())}/>
+        <br/>
+        <span class="icon-text">{tr(strval($custom_text->getValue()))}</span>
+      </span>;
+  }
+}

--- a/src/xhp/Fbbranding.php
+++ b/src/xhp/Fbbranding.php
@@ -6,12 +6,13 @@ class :fbbranding extends :x:element {
   protected string $tagName = 'fbbranding';
 
   protected function render(): XHPRoot {
+    $custom_text = \HH\Asio\join(Configuration::gen('custom_text'));
     return
       <span class="branding-el">
         <svg class="icon icon--social-facebook">
           <use href="#icon--social-facebook" />
         </svg>
-        <span class="has-icon">{' '}{tr('Powered By Facebook')}</span>
+        <span class="has-icon">{' '}{tr(strval($custom_text->getValue()))}</span>
       </span>;
   }
 }

--- a/src/xhp/Fbbranding.php
+++ b/src/xhp/Fbbranding.php
@@ -2,17 +2,18 @@
 
 class :fbbranding extends :x:element {
   category %flow;
+  attribute
+    string brandingText;
 
   protected string $tagName = 'fbbranding';
 
   protected function render(): XHPRoot {
-    $custom_text = \HH\Asio\join(Configuration::gen('custom_text'));
     return
       <span class="branding-el">
         <svg class="icon icon--social-facebook">
           <use href="#icon--social-facebook" />
         </svg>
-        <span class="has-icon">{' '}{tr(strval($custom_text->getValue()))}</span>
+        <span class="has-icon">{' '}{$this->:brandingText}</span>
       </span>;
   }
 }


### PR DESCRIPTION
This pull request implements the customization for brand, which has been requested in https://github.com/facebook/fbctf/issues/203 and https://github.com/facebook/fbctf/issues/93. It allows to customize the logo and the text underneath. By default it is turned off and the displayed text is "Powered By Facebook", with the small FB logo. The new settings are under the "Branding" section:

<img width="243" alt="screen shot 2017-02-11 at 04 34 22" src="https://cloud.githubusercontent.com/assets/1271349/22853767/75545b4e-f013-11e6-848a-bba430e060b6.png">

<img width="655" alt="screen shot 2017-02-11 at 04 25 54" src="https://cloud.githubusercontent.com/assets/1271349/22853744/072ceb2c-f013-11e6-8100-bc4e4af254a6.png">

When enabling the option for a "Custom Logo", the logo can be uploaded, and it will be displayed. The text can be edited at any moment:

<img width="656" alt="screen shot 2017-02-11 at 04 26 32" src="https://cloud.githubusercontent.com/assets/1271349/22853746/137b2d94-f013-11e6-8459-b5f17587b481.png">

Anywhere in the game where the branding is displayed, will have the custom view (Gameboard, Registration, View Mode):

<img width="472" alt="screen shot 2017-02-11 at 04 26 40" src="https://cloud.githubusercontent.com/assets/1271349/22853750/264c216c-f013-11e6-807f-5e7813d1462d.png">