### PR TITLE
Attachments and Links Import/Export, Database Restore, and Control Cleanup

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -39,6 +39,20 @@ class Db {
     return $backup_cmd;
   }
 
+  public function getRestoreCmd(): string {
+    $usr = must_have_idx($this->config, 'DB_USERNAME');
+    $pwd = must_have_idx($this->config, 'DB_PASSWORD');
+    $db = must_have_idx($this->config, 'DB_NAME');
+    $restore_cmd =
+      'mysql -u '.
+      escapeshellarg($usr).
+      ' --password='.
+      escapeshellarg($pwd).
+      ' '.
+      escapeshellarg($db);
+    return $restore_cmd;
+  }
+
   public async function genConnection(): Awaitable<AsyncMysqlConnection> {
     await $this->genConnect();
     invariant($this->conn !== null, 'Connection cant be null.');

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -1000,10 +1000,16 @@ class AdminController extends Controller {
                 <div class="form-el el--block-label el--full-text">
                   <div class="admin-buttons">
                     <button
-                      class="fb-cta cta--yellow"
-                      data-action="backup-db">
-                      {tr('Back Up Database')}
+                      class="fb-cta cta--red"
+                      data-action="import-game">
+                      {tr('Import Full Game')}
                     </button>
+                    <input
+                      class="completely-hidden"
+                      id="import-game_file"
+                      type="file"
+                      name="game_file"
+                    />
                   </div>
                 </div>
               </div>
@@ -1015,23 +1021,6 @@ class AdminController extends Controller {
                       data-action="export-game">
                       {tr('Export Full Game')}
                     </button>
-                  </div>
-                </div>
-              </div>
-              <div class="col col-pad col-1-3">
-                <div class="form-el el--block-label el--full-text">
-                  <div class="admin-buttons">
-                    <button
-                      class="fb-cta cta--yellow"
-                      data-action="import-game">
-                      {tr('Import Full Game')}
-                    </button>
-                    <input
-                      class="completely-hidden"
-                      id="import-game_file"
-                      type="file"
-                      name="game_file"
-                    />
                   </div>
                 </div>
               </div>
@@ -1058,6 +1047,32 @@ class AdminController extends Controller {
                   <div class="admin-buttons">
                     <button class="fb-cta cta--red js-reset-database">
                       {tr('Reset Database')}
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="col col-pad col-1-3">
+                <div class="form-el el--block-label el--full-text">
+                  <div class="admin-buttons">
+                    <button class="fb-cta cta--red js-restore-database">
+                      {tr('Restore Database')}
+                    </button>
+                    <input
+                      class="completely-hidden"
+                      id="restore-database_file"
+                      type="file"
+                      name="database_file"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="col col-pad col-1-3">
+                <div class="form-el el--block-label el--full-text">
+                  <div class="admin-buttons">
+                    <button
+                      class="fb-cta cta--yellow"
+                      data-action="backup-db">
+                      {tr('Backup Database')}
                     </button>
                   </div>
                 </div>
@@ -1160,6 +1175,41 @@ class AdminController extends Controller {
                   </div>
                 </div>
               </div>
+              <div class="col col-pad col-1-4">
+                <div class="form-el el--block-label el--full-text">
+                  <div class="admin-buttons">
+                    <button
+                      class="fb-cta cta--red"
+                      data-action="import-attachments">
+                      {tr('Import Attachments')}
+                    </button>
+                    <input
+                      class="completely-hidden"
+                      id="import-attachments_file"
+                      type="file"
+                      name="attachments_file"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="col col-pad col-1-4">
+                <div class="form-el el--block-label el--full-text">
+                  <div class="admin-buttons">
+                    <button
+                      class="fb-cta cta--yellow"
+                      data-action="export-attachments">
+                      {tr('Export Attachments')}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section class="admin-box">
+            <header class="admin-box-header">
+              <h3>{tr('Categories')}</h3>
+            </header>
+            <div class="fb-column-container">
               <div class="col col-pad col-1-4">
                 <div class="form-el el--block-label el--full-text">
                   <div class="admin-buttons">

--- a/src/controllers/ajax/AdminAjaxController.php
+++ b/src/controllers/ajax/AdminAjaxController.php
@@ -124,17 +124,20 @@ class AdminAjaxController extends AjaxController {
       'pause_game',
       'unpause_game',
       'reset_game',
+      'export_attachments',
       'backup_db',
       'export_game',
       'export_teams',
       'export_logos',
       'export_levels',
       'export_categories',
+      'restore_db',
       'import_game',
       'import_teams',
       'import_logos',
       'import_levels',
       'import_categories',
+      'import_attachments',
       'flush_memcached',
       'reset_database',
     );
@@ -432,8 +435,11 @@ class AdminAjaxController extends AjaxController {
       case 'unpause_game':
         await Control::genUnpause();
         return Utils::ok_response('Success', 'admin');
+      case 'export_attachments':
+        await Control::exportAttachments();
+        return Utils::ok_response('Success', 'admin');
       case 'backup_db':
-        Control::backupDb();
+        await Control::backupDb();
         return Utils::ok_response('Success', 'admin');
       case 'export_game':
         await Control::exportGame();
@@ -450,6 +456,12 @@ class AdminAjaxController extends AjaxController {
       case 'export_categories':
         await Control::exportCategories();
         return Utils::ok_response('Success', 'admin');
+      case 'restore_db':
+        $result = await Control::restoreDb();
+        if ($result) {
+          return Utils::ok_response('Success', 'admin');
+        }
+        return Utils::error_response('Error importing', 'admin');
       case 'import_game':
         $result = await Control::importGame();
         if ($result) {
@@ -476,6 +488,12 @@ class AdminAjaxController extends AjaxController {
         return Utils::error_response('Error importing', 'admin');
       case 'import_categories':
         $result = await Control::importCategories();
+        if ($result) {
+          return Utils::ok_response('Success', 'admin');
+        }
+        return Utils::error_response('Error importing', 'admin');
+      case 'import_attachments':
+        $result = await Control::importAttachments();
         if ($result) {
           return Utils::ok_response('Success', 'admin');
         }

--- a/src/controllers/importers/BinaryImporterController.php
+++ b/src/controllers/importers/BinaryImporterController.php
@@ -1,0 +1,12 @@
+<?hh // strict
+
+class BinaryImporterController {
+  public static function getFilename(string $file_name): mixed {
+    $file = Utils::getFILES();
+    if ($file->contains($file_name)) {
+      $input_filename = $file[$file_name]['tmp_name'];
+      return $input_filename;
+    }
+    return false;
+  }
+}

--- a/src/controllers/modals/ActionModalController.php
+++ b/src/controllers/modals/ActionModalController.php
@@ -189,10 +189,30 @@ class ActionModalController extends ModalController {
           <div class="action-main">
             <p>{tr('Items have been imported successfully')}</p>
             <div class="action-actionable">
-              <a
-                href="#"
-                class="fb-cta cta--yellow js-close-modal js-confirm-save">
+              <a href="#" class="fb-cta cta--yellow js-close-modal">
                 {tr('OK')}
+              </a>
+            </div>
+          </div>;
+        return tuple($title, $content);
+      case 'restore-database':
+        $title =
+          <h4>
+            {tr('restore_')}<span class="highlighted">{tr('Database')}</span>
+          </h4>;
+        $content =
+          <div class="action-main">
+            <p>
+              {tr(
+                'Are you sure you want to restore the database? This will overwrite ALL existing data!',
+              )}
+            </p>
+            <div class="action-actionable">
+              <a href="#" class="fb-cta cta--red js-close-modal">
+                {tr('No')}
+              </a>
+              <a href="#" id="restore_database" class="fb-cta cta--yellow">
+                {tr('Yes')}
               </a>
             </div>
           </div>;

--- a/src/models/Attachment.php
+++ b/src/models/Attachment.php
@@ -36,10 +36,6 @@ class Attachment extends Model {
     return $this->levelId;
   }
 
-  public static function getAttachmentDir(): string {
-    return strval(self::attachmentsDir);
-  }
-
   // Create attachment for a given level.
   public static async function genCreate(
     string $file_param,

--- a/src/models/Attachment.php
+++ b/src/models/Attachment.php
@@ -17,6 +17,7 @@ class Attachment extends Model {
     private int $id,
     private int $levelId,
     private string $filename,
+    private string $type,
   ) {}
 
   public function getId(): int {
@@ -27,8 +28,16 @@ class Attachment extends Model {
     return $this->filename;
   }
 
+  public function getType(): string {
+    return $this->type;
+  }
+
   public function getLevelId(): int {
     return $this->levelId;
+  }
+
+  public static function getAttachmentDir(): string {
+    return strval(self::attachmentsDir);
   }
 
   // Create attachment for a given level.
@@ -265,6 +274,22 @@ class Attachment extends Model {
     }
   }
 
+  public static async function genImportAttachments(
+    int $level_id,
+    string $filename,
+    string $type,
+  ): Awaitable<bool> {
+    $db = await self::genDb();
+    await $db->queryf(
+      'INSERT INTO attachments (filename, type, level_id, created_ts) VALUES (%s, %s, %d, NOW())',
+      $filename,
+      (string) $type,
+      $level_id,
+    );
+
+    return true;
+  }
+
   private static function attachmentFromRow(
     Map<string, string> $row,
   ): Attachment {
@@ -272,6 +297,7 @@ class Attachment extends Model {
       intval(must_have_idx($row, 'id')),
       intval(must_have_idx($row, 'level_id')),
       must_have_idx($row, 'filename'),
+      must_have_idx($row, 'type'),
     );
   }
 }

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -251,6 +251,7 @@ class Control extends Model {
       if (!$levels_result) {
         return false;
       }
+      await self::genFlushMemcached();
       return true;
     }
     return false;
@@ -260,6 +261,7 @@ class Control extends Model {
     $data_teams = JSONImporterController::readJSON('teams_file');
     if (is_array($data_teams)) {
       $teams = must_have_idx($data_teams, 'teams');
+      await self::genFlushMemcached();
       return await Team::importAll($teams);
     }
     return false;
@@ -269,6 +271,7 @@ class Control extends Model {
     $data_logos = JSONImporterController::readJSON('logos_file');
     if (is_array($data_logos)) {
       $logos = must_have_idx($data_logos, 'logos');
+      await self::genFlushMemcached();
       return await Logo::importAll($logos);
     }
     return false;
@@ -278,6 +281,7 @@ class Control extends Model {
     $data_levels = JSONImporterController::readJSON('levels_file');
     if (is_array($data_levels)) {
       $levels = must_have_idx($data_levels, 'levels');
+      await self::genFlushMemcached();
       return await Level::importAll($levels);
     }
     return false;
@@ -287,9 +291,53 @@ class Control extends Model {
     $data_categories = JSONImporterController::readJSON('categories_file');
     if (is_array($data_categories)) {
       $categories = must_have_idx($data_categories, 'categories');
+      await self::genFlushMemcached();
       return await Category::importAll($categories);
     }
     return false;
+  }
+
+  public static async function importAttachments(): Awaitable<bool> {
+    $output = array();
+    $status = 0;
+    $filename =
+      strval(BinaryImporterController::getFilename('attachments_file'));
+    $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
+    $directory = $document_root.Attachment::getAttachmentDir();
+    $cmd = "tar -zx -C $directory -f $filename";
+    exec($cmd, $output, $status);
+    if (intval($status) !== 0) {
+      return false;
+    }
+    $directory_files = scandir($directory);
+    foreach ($directory_files as $file) {
+      $chmod = chmod($directory.$file, 0600);
+      invariant(
+        $chmod === true,
+        'Failed to set attachment file permissions to 0600',
+      );
+    }
+    await self::genFlushMemcached();
+    return true;
+  }
+
+  public static async function restoreDb(): Awaitable<bool> {
+    $output = array();
+    $status = 0;
+    $filename =
+      strval(BinaryImporterController::getFilename('database_file'));
+    $cmd = "cat $filename | gunzip - ";
+    exec($cmd, $output, $status);
+    if (intval($status) !== 0) {
+      return false;
+    }
+    $cmd = "cat $filename | gunzip - | ".Db::getInstance()->getRestoreCmd();
+    exec($cmd, $output, $status);
+    if (intval($status) !== 0) {
+      return false;
+    }
+    await self::genFlushMemcached();
+    return true;
   }
 
   public static async function exportGame(): Awaitable<void> {
@@ -335,12 +383,24 @@ class Control extends Model {
     exit();
   }
 
-  public static function backupDb(): void {
+  public static async function exportAttachments(): Awaitable<void> {
+    $filename = 'fbctf-attachments-'.date("d-m-Y").'.tgz';
+    header('Content-Type: application/x-tgz');
+    header('Content-Disposition: attachment; filename="'.$filename.'"');
+    $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
+    $directory = $document_root.Attachment::getAttachmentDir();
+    $cmd = "tar -cz -C $directory . ";
+    passthru($cmd);
+    exit();
+  }
+
+  public static async function backupDb(): Awaitable<void> {
     $filename = 'fbctf-backup-'.date("d-m-Y").'.sql.gz';
     header('Content-Type: application/x-gzip');
     header('Content-Disposition: attachment; filename="'.$filename.'"');
     $cmd = Db::getInstance()->getBackupCmd().' | gzip --best';
     passthru($cmd);
+    exit();
   }
 
   public static async function genAllActivity(

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -303,7 +303,7 @@ class Control extends Model {
     $filename =
       strval(BinaryImporterController::getFilename('attachments_file'));
     $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
-    $directory = $document_root.Attachment::getAttachmentDir();
+    $directory = $document_root.Attachment::attachmentsDir;
     $cmd = "tar -zx -C $directory -f $filename";
     exec($cmd, $output, $status);
     if (intval($status) !== 0) {
@@ -388,7 +388,7 @@ class Control extends Model {
     header('Content-Type: application/x-tgz');
     header('Content-Disposition: attachment; filename="'.$filename.'"');
     $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
-    $directory = $document_root.Attachment::getAttachmentDir();
+    $directory = $document_root.Attachment::attachmentsDir;
     $cmd = "tar -cz -C $directory . ";
     passthru($cmd);
     exit();

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -158,7 +158,7 @@ class Level extends Model implements Importable, Exportable {
       if (!$exist && $entity_exist && $category_exist) {
         $entity = await Country::genCountry($entity_iso_code);
         $category = await Category::genSingleCategoryByName($c);
-        await self::genCreate(
+        $level_id = await self::genCreate(
           $type,
           $title,
           must_have_string($level, 'description'),
@@ -172,6 +172,23 @@ class Level extends Model implements Importable, Exportable {
           must_have_string($level, 'hint'),
           must_have_int($level, 'penalty'),
         );
+        $links = must_have_idx($level, 'links');
+        invariant(is_array($links), 'links must be of type array');
+        foreach ($links as $link) {
+          await Link::genCreate($link, $level_id);
+        }
+        $attachments = must_have_idx($level, 'attachments');
+        invariant(
+          is_array($attachments),
+          'attachments must be of type array',
+        );
+        foreach ($attachments as $attachment) {
+          await Attachment::genImportAttachments(
+            $level_id,
+            $attachment['filename'],
+            $attachment['type'],
+          );
+        }
       }
     }
     return true;
@@ -186,6 +203,19 @@ class Level extends Model implements Importable, Exportable {
     foreach ($all_levels as $level) {
       $entity = await Country::gen($level->getEntityId());
       $category = await Category::genSingleCategory($level->getCategoryId());
+      $links = await Link::genAllLinks($level->getId());
+      $link_array = array();
+      foreach ($links as $link) {
+        $link_array[] = $link->getLink();
+      }
+      $attachments = await Attachment::genAllAttachments($level->getId());
+      $attachment_array = array();
+      foreach ($attachments as $attachment) {
+        $attachment_array[] = [
+          "filename" => $attachment->getFilename(),
+          "type" => $attachment->getType(),
+        ];
+      }
       $one_level = array(
         'type' => $level->getType(),
         'title' => $level->getTitle(),
@@ -200,6 +230,8 @@ class Level extends Model implements Importable, Exportable {
         'flag' => $level->getFlag(),
         'hint' => $level->getHint(),
         'penalty' => $level->getPenalty(),
+        'links' => $link_array,
+        'attachments' => $attachment_array,
       );
       array_push($all_levels_data, $one_level);
     }

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -212,8 +212,8 @@ class Level extends Model implements Importable, Exportable {
       $attachment_array = array();
       foreach ($attachments as $attachment) {
         $attachment_array[] = [
-          "filename" => $attachment->getFilename(),
-          "type" => $attachment->getType(),
+          'filename' => $attachment->getFilename(),
+          'type' => $attachment->getType(),
         ];
       }
       $one_level = array(

--- a/src/static/js/admin.js
+++ b/src/static/js/admin.js
@@ -408,6 +408,14 @@ function createAnnouncement(section) {
   }
 }
 
+//Create and download attachments backup
+function attachmentsExport() {
+  var csrf_token = $('input[name=csrf_token]')[0].value;
+  var action = 'export_attachments';
+  var url = 'index.php?p=admin&ajax=true&action=' + action + '&csrf_token=' + csrf_token;
+  window.location.href = url;
+}
+
 // Create and download database backup
 function databaseBackup() {
   var csrf_token = $('input[name=csrf_token]')[0].value;
@@ -444,13 +452,28 @@ function submitImport(type_file, action_file) {
     var responseData = JSON.parse(data);
     if (responseData.result == 'OK') {
       console.log('OK');
-       Modal.loadPopup('p=action&modal=import-done', 'action-import');
+       Modal.loadPopup('p=action&modal=import-done', 'action-import', function() {
+         var ok_button = $("a[class='fb-cta cta--yellow js-close-modal']");
+         ok_button.attr('href', '?p=admin&page=controls');
+         ok_button.removeClass('js-close-modal');
+       });
     } else {
       console.log('Failed');
       Modal.loadPopup('p=action&modal=error', 'action-error', function() {
         $('.error-text').html('<p>Sorry there was a problem importing the items. Please try again.</p>');
+        var ok_button = $("a[class='fb-cta cta--yellow js-close-modal']");
+        ok_button.attr('href', '?p=admin&page=controls');
+        ok_button.removeClass('js-close-modal');
       });
     }
+  });
+}
+
+//Restore and replace database
+function databaseRestore() {
+  $('#restore-database_file').trigger('click');
+  $('#restore-database_file').change(function() {
+    submitImport('database_file', 'restore_db');
   });
 }
 
@@ -491,6 +514,14 @@ function importLevels() {
   $('#import-levels_file').trigger('click');
   $('#import-levels_file').change(function() {
     submitImport('levels_file', 'import_levels');
+  });
+}
+
+//Import and replace current attachments
+function importAttachments() {
+  $('#import-attachments_file').trigger('click');
+  $('#import-attachments_file').change(function() {
+    submitImport('attachments_file', 'import_attachments');
   });
 }
 
@@ -1023,6 +1054,8 @@ module.exports = {
         }
       } else if (action === 'create-announcement') {
         createAnnouncement($section);
+      } else if (action === 'export-attachments') {
+        attachmentsExport();
       } else if (action === 'backup-db') {
         databaseBackup();
       } else if (action === 'import-game') {
@@ -1043,6 +1076,8 @@ module.exports = {
         exportCurrentLogos();
       } else if (action === 'import-levels') {
         importLevels();
+      } else if (action === 'import-attachments') {
+        importAttachments();
       } else if (action === 'export-levels') {
         exportCurrentLevels();
       } else if (action === 'import-categories') {
@@ -1389,5 +1424,12 @@ module.exports = {
       });
     });
 
+    // prompt restore database
+    $('.js-restore-database').on('click', function(event) {
+      event.preventDefault();
+      Modal.loadPopup('p=action&modal=restore-database', 'action-restore-database', function() {
+        $('#restore_database').click(databaseRestore);
+      });
+    });
   }
 };


### PR DESCRIPTION
* Attachments can now be exported and imported.  On export, attachments are downloaded into a Tar Gzip and securely extracted on import.

* Links and Attachments data is now provided within the Levels export.  Users must import both the Level data and the Attachment files to restore the levels with attachments.

* A database restore option has been added which utilizes the backed up database content.  This overwrites all data in the database.

* The Control page has been reorganized to align the various functionality better.

<img width="1335" src="https://cloud.githubusercontent.com/assets/22864312/22860909/112a0ab2-f0d9-11e6-96aa-ec6a5321c89b.png">

* Memcached flushing has been added to all relevant data imports.

* Error handling has been added to the various import functions.