### PR TITLE
Require bxslider version 4.2.6 (Fixes #455)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "jquery": "^2.2.3",
     "keycode": "^2.1.1",
     "typed.js": "^1.1.1",
-    "bxslider": "~4.2.6"
+    "bxslider": "4.2.6"
   }
 }


### PR DESCRIPTION
* This resolves a current build error #455.

* bxslider was updated from 4.2.6 to 4.2.7 on February 14th.  Previously FBCTF allowed for a near match to 4.2.6.  However, FBCTF fails to build with 4.2.7.  During the installation process grunt failed to build the browserify javascript.