### PR TITLE
Auto Announcements and Activity Log Expansion

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -211,6 +211,7 @@ INSERT INTO `configuration` (field, value, description) VALUES("pause_ts", "0", 
 INSERT INTO `configuration` (field, value, description) VALUES("timer", "0", "(Boolean) Timer is enabled");
 INSERT INTO `configuration` (field, value, description) VALUES("scoring", "0", "(Boolean) Ability score levels");
 INSERT INTO `configuration` (field, value, description) VALUES("gameboard", "1", "(Boolean) Refresh all data in the gameboard");
+INSERT INTO `configuration` (field, value, description) VALUES("auto_announce", "0", "(Boolean) Auto game announcements");
 INSERT INTO `configuration` (field, value, description) VALUES("progressive_cycle", "300", "(Integer) Frequency to take progressive scoreboard in seconds");
 INSERT INTO `configuration` (field, value, description) VALUES("bases_cycle", "5", "(Integer) Frequency to score base levels in seconds");
 INSERT INTO `configuration` (field, value, description) VALUES("autorun_cycle", "30", "(Integer) Frequency to cycle autorun in seconds");
@@ -414,6 +415,25 @@ CREATE TABLE `announcements_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `ts` timestamp NOT NULL,
   `announcement` text NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `activity_log`
+--
+
+DROP TABLE IF EXISTS `activity_log`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `activity_log` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `subject` text NOT NULL,
+  `action` text NOT NULL,
+  `entity` text NOT NULL,
+  `message` text NOT NULL,
+  `arguments` text NOT NULL,
+  `ts` timestamp NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -211,6 +211,7 @@ INSERT INTO `configuration` (field, value, description) VALUES("pause_ts", "0", 
 INSERT INTO `configuration` (field, value, description) VALUES("timer", "0", "(Boolean) Timer is enabled");
 INSERT INTO `configuration` (field, value, description) VALUES("scoring", "0", "(Boolean) Ability score levels");
 INSERT INTO `configuration` (field, value, description) VALUES("gameboard", "1", "(Boolean) Refresh all data in the gameboard");
+INSERT INTO `configuration` (field, value, description) VALUES("auto_announce", "0", "(Boolean) Auto game announcements");
 INSERT INTO `configuration` (field, value, description) VALUES("progressive_cycle", "300", "(Integer) Frequency to take progressive scoreboard in seconds");
 INSERT INTO `configuration` (field, value, description) VALUES("bases_cycle", "5", "(Integer) Frequency to score base levels in seconds");
 INSERT INTO `configuration` (field, value, description) VALUES("autorun_cycle", "30", "(Integer) Frequency to cycle autorun in seconds");
@@ -411,6 +412,25 @@ CREATE TABLE `announcements_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `ts` timestamp NOT NULL,
   `announcement` text NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `activity_log`
+--
+
+DROP TABLE IF EXISTS `activity_log`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `activity_log` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `subject` text NOT NULL,
+  `action` text NOT NULL,
+  `entity` text NOT NULL,
+  `message` text NOT NULL,
+  `arguments` text NOT NULL,
+  `ts` timestamp NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -304,6 +304,7 @@ class AdminController extends Controller {
       'ldap_domain_suffix' => Configuration::gen('ldap_domain_suffix'),
       'scoring' => Configuration::gen('scoring'),
       'gameboard' => Configuration::gen('gameboard'),
+      'auto_announce' => Configuration::gen('auto_announce'),
       'timer' => Configuration::gen('timer'),
       'progressive_cycle' => Configuration::gen('progressive_cycle'),
       'default_bonus' => Configuration::gen('default_bonus'),
@@ -334,6 +335,7 @@ class AdminController extends Controller {
     $ldap_domain_suffix = $results['ldap_domain_suffix'];
     $scoring = $results['scoring'];
     $gameboard = $results['gameboard'];
+    $auto_announce = $results['auto_announce'];
     $timer = $results['timer'];
     $progressive_cycle = $results['progressive_cycle'];
     $default_bonus = $results['default_bonus'];
@@ -364,6 +366,8 @@ class AdminController extends Controller {
     $scoring_off = $scoring->getValue() === '0';
     $gameboard_on = $gameboard->getValue() === '1';
     $gameboard_off = $gameboard->getValue() === '0';
+    $auto_announce_on = $auto_announce->getValue() === '1';
+    $auto_announce_off = $auto_announce->getValue() === '0';
     $timer_on = $timer->getValue() === '1';
     $timer_off = $timer->getValue() === '0';
     $livesync_on = $livesync->getValue() === '1';
@@ -798,6 +802,29 @@ class AdminController extends Controller {
                         value={$autorun_cycle->getValue()}
                         name="fb--conf--autorun_cycle"
                       />
+                    </div>
+                    <div class="form-el el--block-label">
+                      <label>{tr('Auto Announcements')}</label>
+                      <div class="admin-section-toggle radio-inline">
+                        <input
+                          type="radio"
+                          name="fb--conf--auto_announce"
+                          id="fb--conf--auto_announce--on"
+                          checked={$auto_announce_on}
+                        />
+                        <label for="fb--conf--auto_announce--on">
+                          {tr('On')}
+                        </label>
+                        <input
+                          type="radio"
+                          name="fb--conf--auto_announce"
+                          id="fb--conf--auto_announce--off"
+                          checked={$auto_announce_off}
+                        />
+                        <label for="fb--conf--auto_announce--off">
+                          {tr('Off')}
+                        </label>
+                      </div>
                     </div>
                     <div class="form-el el--block-label"></div>
                   </div>

--- a/src/models/ActivityLog.php
+++ b/src/models/ActivityLog.php
@@ -1,0 +1,277 @@
+<?hh // strict
+
+class ActivityLog extends Model {
+
+  protected static string $MC_KEY = 'activitylog:';
+
+  protected static Map<string, string>
+    $MC_KEYS = Map {'ALL_ACTIVITY' => 'activity'};
+
+  private function __construct(
+    private int $id,
+    private string $subject,
+    private string $action,
+    private string $entity,
+    private string $message,
+    private string $arguments,
+    private string $ts,
+    private string $formatted_subject = '',
+    private string $formatted_entity = '',
+    private string $formatted_message = '',
+  ) {
+    $formatted_subject =
+      \HH\Asio\join(self::genFormatString("%s", $this->subject));
+    $this->formatted_subject = $formatted_subject;
+    $formatted_entity =
+      \HH\Asio\join(self::genFormatString("%s", $this->entity));
+    $this->formatted_entity = $formatted_entity;
+    $formatted_message =
+      \HH\Asio\join(self::genFormatString($this->message, $this->arguments));
+    $this->formatted_message = $formatted_message;
+  }
+
+  public function getId(): int {
+    return $this->id;
+  }
+
+  public function getSubject(): string {
+    return $this->subject;
+  }
+
+  public function getAction(): string {
+    return $this->action;
+  }
+
+  public function getEntity(): string {
+    return $this->entity;
+  }
+
+  public function getMessage(): string {
+    return $this->message;
+  }
+
+  public function getArguments(): string {
+    return $this->arguments;
+  }
+
+  public function getFormattedSubject(): string {
+    return $this->formatted_subject;
+  }
+
+  public function getFormattedEntity(): string {
+    return $this->formatted_entity;
+  }
+
+  public function getFormattedMessage(): string {
+    return $this->formatted_message;
+  }
+
+  public function getTs(): string {
+    return $this->ts;
+  }
+
+  private static function activitylogFromRow(
+    Map<string, string> $row,
+  ): ActivityLog {
+    return new ActivityLog(
+      intval(must_have_idx($row, 'id')),
+      must_have_idx($row, 'subject'),
+      must_have_idx($row, 'action'),
+      must_have_idx($row, 'entity'),
+      must_have_idx($row, 'message'),
+      must_have_idx($row, 'arguments'),
+      must_have_idx($row, 'ts'),
+    );
+  }
+
+  public static async function genFormatString(
+    string $string,
+    string $arguments,
+  ): Awaitable<string> {
+    if ($arguments !== '') {
+      $variables = array();
+      $values_array = explode(',', $arguments);
+      foreach ($values_array as $value) {
+        list($class, $id) = explode(':', $value);
+        switch ($class) {
+          case "Team":
+            $team_exists = await Team::genTeamExistById(intval($id));
+            if ($team_exists === true) {
+              $team = await Team::genTeam(intval($id));
+              $variables[] = $team->getName();
+            } else {
+              return '';
+            }
+            break;
+          case "Level":
+            $level_exists = await Level::genAlreadyExistById(intval($id));
+            if ($level_exists === true) {
+              $level = await Level::gen(intval($id));
+              $variables[] = $level->getTitle();
+            } else {
+              return '';
+            }
+            break;
+          case "Country":
+            $country_exists = await Country::genCheckExistsById(intval($id));
+            if ($country_exists === true) {
+              $country = await Country::gen(intval($id));
+              $variables[] = $country->getIsoCode();
+            } else {
+              return '';
+            }
+            break;
+            // FALLTHROUGH
+          default:
+            return '';
+            break;
+        }
+      }
+      $formatted = vsprintf($string, $variables);
+      return $formatted;
+    }
+    return $string;
+  }
+
+  public static async function genCreate(
+    string $subject,
+    string $action,
+    string $entity,
+    string $message,
+    string $arguments,
+  ): Awaitable<void> {
+    $db = await self::genDb();
+    await $db->queryf(
+      'INSERT INTO activity_log (ts, subject, action, entity, message, arguments) (SELECT NOW(), %s, %s, %s, %s, %s) LIMIT 1',
+      $subject,
+      $action,
+      $entity,
+      $message,
+      $arguments,
+    );
+
+    self::invalidateMCRecords(); // Invalidate Memcached ActivityLog data.
+  }
+
+  public static async function genCaptureLog(
+    int $team_id,
+    int $level_id,
+  ): Awaitable<void> {
+    //$level = await Level::gen($level_id);
+    $country_id = await Level::genCountryIdForLevel($level_id);
+    await self::genCreateActionLog(
+      "Team",
+      $team_id,
+      "captured",
+      "Country",
+      $country_id,
+    );
+  }
+
+  public static async function genCreateActionLog(
+    string $subject_class,
+    int $subject_id,
+    string $action,
+    string $entity_class,
+    int $entity_id,
+  ): Awaitable<void> {
+    await self::genCreate(
+      "$subject_class:$subject_id",
+      $action,
+      "$entity_class:$entity_id",
+      '',
+      '',
+    );
+  }
+
+  public static async function genCreateGameActionLog(
+    string $subject_class,
+    int $subject_id,
+    string $action,
+    string $entity_class,
+    int $entity_id,
+  ): Awaitable<void> {
+    $config_game = await Configuration::gen('game');
+    $config_pause = await Configuration::gen('game_paused');
+    if ((intval($config_game->getValue()) === 1) &&
+        (intval($config_pause->getValue()) === 0)) {
+      await self::genCreate(
+        "$subject_class:$subject_id",
+        $action,
+        "$entity_class:$entity_id",
+        '',
+        '',
+      );
+    }
+  }
+
+  public static async function genAdminLog(
+    string $action,
+    string $entity_class,
+    int $entity_id,
+  ): Awaitable<void> {
+    if (SessionUtils::sessionActive() === false) {
+      return;
+    }
+    await self::genCreateGameActionLog(
+      "Team",
+      SessionUtils::sessionTeam(),
+      $action,
+      $entity_class,
+      $entity_id,
+    );
+  }
+
+  public static async function genCreateGenericLog(
+    string $message,
+    string $arguments = '',
+  ): Awaitable<void> {
+    await self::genCreate('', '', '', $message, $arguments);
+  }
+
+  public static async function genDelete(
+    int $activity_log_id,
+  ): Awaitable<void> {
+    $db = await self::genDb();
+    await $db->queryf(
+      'DELETE FROM activity_log WHERE id = %d LIMIT 1',
+      $activity_log_id,
+    );
+
+    self::invalidateMCRecords(); // Invalidate Memcached Announcement data.
+  }
+
+  public static async function genDeleteAll(): Awaitable<void> {
+    $db = await self::genDb();
+    await $db->queryf('TRUNCATE TABLE activity_log');
+
+    self::invalidateMCRecords(); // Invalidate Memcached Announcement data.
+  }
+
+  public static async function genAllActivity(
+    bool $refresh = false,
+  ): Awaitable<array<ActivityLog>> {
+    $mc_result = self::getMCRecords('ALL_ACTIVITY');
+    if (!$mc_result || count($mc_result) === 0 || $refresh) {
+      $db = await self::genDb();
+      $activity_log_lines = array();
+      $result =
+        await $db->queryf('SELECT * FROM activity_log ORDER BY ts DESC');
+      foreach ($result->mapRows() as $row) {
+        $activity_log = self::activitylogFromRow($row);
+        if (($activity_log->getFormattedMessage() !== '') ||
+            (($activity_log->getFormattedSubject() !== '') &&
+             ($activity_log->getFormattedEntity() !== ''))) {
+          $activity_log_lines[] = $activity_log;
+        }
+      }
+      self::setMCRecords('ALL_ACTIVITY', $activity_log_lines);
+      return $activity_log_lines;
+    }
+    invariant(
+      is_array($mc_result),
+      'cache return should be an array of ActivityLog',
+    );
+    return $mc_result;
+  }
+}

--- a/src/models/Control.php
+++ b/src/models/Control.php
@@ -47,6 +47,18 @@ class Control extends Model {
     // Disable registration
     await Configuration::genUpdate('registration', '0');
 
+    // Clear announcements log
+    await Announcement::genDeleteAll();
+
+    // Clear activity log
+    await ActivityLog::genDeleteAll();
+
+    // Announce game starting
+    await Announcement::genCreateAuto('Game has started!');
+
+    // Log game starting
+    await ActivityLog::genCreateGenericLog('Game has started!');
+
     // Reset all points
     await Team::genResetAllPoints();
 
@@ -122,6 +134,12 @@ class Control extends Model {
   }
 
   public static async function genEnd(): Awaitable<void> {
+    // Announce game ending
+    await Announcement::genCreateAuto('Game has ended!');
+
+    // Log game ending
+    await ActivityLog::genCreateGenericLog('Game has ended!');
+
     // Mark game as finished and it stops progressive scoreboard
     await Configuration::genUpdate('game', '0');
 
@@ -155,6 +173,12 @@ class Control extends Model {
   }
 
   public static async function genPause(): Awaitable<void> {
+    // Announce game starting
+    await Announcement::genCreateAuto('Game has been paused!');
+
+    // Log game paused
+    await ActivityLog::genCreateGenericLog('Game has been paused!');
+
     // Disable scoring
     await Configuration::genUpdate('scoring', '0');
 
@@ -214,6 +238,12 @@ class Control extends Model {
 
     // Kick off scoring for bases
     await Level::genBaseScoring();
+
+    // Announce game resumed
+    await Announcement::genCreateAuto('Game has resumed!');
+
+    // Log game paused
+    await ActivityLog::genCreateGenericLog('Game has resumed!');
   }
 
   public static async function genAutoBegin(): Awaitable<void> {

--- a/src/models/Country.php
+++ b/src/models/Country.php
@@ -330,4 +330,23 @@ class Country extends Model {
     }
   }
 
+  // Check if a country already exists, by id
+  public static async function genCheckExistsById(
+    int $entity_id,
+  ): Awaitable<bool> {
+    $db = await self::genDb();
+
+    $result = await $db->queryf(
+      'SELECT COUNT(*) FROM countries WHERE id = %d',
+      $entity_id,
+    );
+
+    if ($result->numRows() > 0) {
+      invariant($result->numRows() === 1, 'Expected exactly one result');
+      return (intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0);
+    } else {
+      return false;
+    }
+  }
+
 }

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -379,6 +379,15 @@ class Level extends Model implements Importable, Exportable {
 
     self::invalidateMCRecords(); // Invalidate Memcached Level data.
     invariant($result->numRows() === 1, 'Expected exactly one result');
+
+    $country_id = await self::genCountryIdForLevel(
+      intval(must_have_idx($result->mapRows()[0], 'id')),
+    );
+    await ActivityLog::genAdminLog("added", "Country", $country_id);
+    $country = await Country::gen($country_id);
+    await Announcement::genCreateAuto($country->getName()." added!");
+    ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
+
     return intval(must_have_idx($result->mapRows()[0], 'id'));
   }
 
@@ -592,29 +601,36 @@ class Level extends Model implements Importable, Exportable {
       $ent_id = $entity_id;
     }
 
-    await $db->queryf(
-      'UPDATE levels SET title = %s, description = %s, entity_id = %d, category_id = %d, points = %d, '.
-      'bonus = %d, bonus_dec = %d, bonus_fix = %d, flag = %s, hint = %s, '.
-      'penalty = %d WHERE id = %d LIMIT 1',
-      $title,
-      $description,
-      $ent_id,
-      $category_id,
-      $points,
-      $bonus,
-      $bonus_dec,
-      $bonus_fix,
-      $flag,
-      $hint,
-      $penalty,
-      $level_id,
-    );
+    $result =
+      await $db->queryf(
+        'UPDATE levels SET title = %s, description = %s, entity_id = %d, category_id = %d, points = %d, '.
+        'bonus = %d, bonus_dec = %d, bonus_fix = %d, flag = %s, hint = %s, '.
+        'penalty = %d WHERE id = %d LIMIT 1',
+        $title,
+        $description,
+        $ent_id,
+        $category_id,
+        $points,
+        $bonus,
+        $bonus_dec,
+        $bonus_fix,
+        $flag,
+        $hint,
+        $penalty,
+        $level_id,
+      );
 
     // Make sure entities are consistent
     await Country::genUsedAdjust();
 
-    self::invalidateMCRecords(); // Invalidate Memcached Level data.
-    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    if ($result->numRowsAffected() > 0) {
+      $country_id = await self::genCountryIdForLevel($level_id);
+      await ActivityLog::genAdminLog("updated", "Country", $country_id);
+      $country = await Country::gen($country_id);
+      await Announcement::genCreateAuto($country->getName()." updated!");
+      self::invalidateMCRecords(); // Invalidate Memcached Level data.
+      ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
+    }
   }
 
   // Delete level.
@@ -637,13 +653,21 @@ class Level extends Model implements Importable, Exportable {
   ): Awaitable<void> {
     $db = await self::genDb();
 
-    await $db->queryf(
+    $result = await $db->queryf(
       'UPDATE levels SET active = %d WHERE id = %d LIMIT 1',
       (int) $active,
       $level_id,
     );
 
-    self::invalidateMCRecords(); // Invalidate Memcached Level data.
+    if ($result->numRowsAffected() > 0) {
+      $action = ($active === true) ? "enabled" : "disabled";
+      $country_id = await self::genCountryIdForLevel($level_id);
+      await ActivityLog::genAdminLog($action, "Country", $country_id);
+      $country = await Country::gen($country_id);
+      await Announcement::genCreateAuto($country->getName().' '.$action.'!');
+      self::invalidateMCRecords(); // Invalidate Memcached Level data.
+      ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
+    }
   }
 
   // Enable or disable levels by type.
@@ -653,13 +677,15 @@ class Level extends Model implements Importable, Exportable {
   ): Awaitable<void> {
     $db = await self::genDb();
 
-    await $db->queryf(
+    $results = await $db->queryf(
       'UPDATE levels SET active = %d WHERE type = %s',
       (int) $active,
       $type,
     );
 
-    self::invalidateMCRecords(); // Invalidate Memcached Level data.
+    if ($results->numRowsAffected() > 0) {
+      self::invalidateMCRecords(); // Invalidate Memcached Level data.
+    }
   }
 
   // Enable or disable all levels.
@@ -670,19 +696,20 @@ class Level extends Model implements Importable, Exportable {
     $db = await self::genDb();
 
     if ($type === 'all') {
-      await $db->queryf(
-        'UPDATE levels SET active = %d WHERE id > 0',
-        (int) $active,
+      $result = await $db->queryf(
+        'SELECT id FROM levels WHERE active = %d AND id >0',
+        (int) !$active,
       );
     } else {
-      await $db->queryf(
-        'UPDATE levels SET active = %d WHERE type = %s',
-        (int) $active,
+      $result = await $db->queryf(
+        'SELECT id FROM levels WHERE active = %d AND type = %s',
+        (int) !$active,
         $type,
       );
     }
-
-    self::invalidateMCRecords(); // Invalidate Memcached Level data.
+    foreach ($result->mapRows() as $row) {
+      await self::genSetStatus(intval($row->get('id')), $active);
+    }
   }
 
   // All levels.
@@ -939,7 +966,7 @@ class Level extends Model implements Importable, Exportable {
     $lock = fopen($lock_name, 'w');
 
     if ($lock === false) {
-      error_log('Failed to open lock file $lock_name');
+      error_log('Failed to open lock file '.$lock_name);
       return null;
     }
     if (!flock($lock, LOCK_EX)) {
@@ -1094,7 +1121,7 @@ class Level extends Model implements Importable, Exportable {
           // Log the hint
           await HintLog::genLogGetHint($level_id, $team_id, $penalty);
 
-          Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+          ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
           MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
           MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
           MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.
@@ -1208,6 +1235,33 @@ class Level extends Model implements Importable, Exportable {
     }
   }
 
+  // Check if a level already exists by type, title and entity.
+  public static async function genAlreadyExistById(
+    int $level_id,
+  ): Awaitable<bool> {
+    $db = await self::genDb();
+
+    $result = await $db->queryf(
+      'SELECT COUNT(*) FROM levels WHERE id = %d',
+      $level_id,
+    );
+
+    if ($result->numRows() > 0) {
+      invariant($result->numRows() === 1, 'Expected exactly one result');
+      return (intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0);
+    } else {
+      return false;
+    }
+  }
+
+  // Check if a level already exists by type, title and entity.
+  public static async function genCountryIdForLevel(
+    int $level_id,
+  ): Awaitable<int> {
+    $level = await self::gen($level_id);
+    return $level->getEntityId();
+  }
+
   public static async function getLevelIdByTypeTitleCountry(
     string $type,
     string $title,
@@ -1234,7 +1288,6 @@ class Level extends Model implements Importable, Exportable {
     int $points,
   ): Awaitable<bool> {
     $db = await self::genDb();
-
     $result =
       await $db->queryf(
         'SELECT COUNT(*) FROM levels WHERE type = %s AND title = %s AND description = %s AND points = %d',
@@ -1243,7 +1296,6 @@ class Level extends Model implements Importable, Exportable {
         $description,
         $points,
       );
-
     if ($result->numRows() > 0) {
       invariant($result->numRows() === 1, 'Expected exactly one result');
       return (intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0);

--- a/src/models/ScoreLog.php
+++ b/src/models/ScoreLog.php
@@ -69,7 +69,7 @@ class ScoreLog extends Model {
     $db = await self::genDb();
     await $db->queryf('DELETE FROM scores_log WHERE id > 0');
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
-    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.
@@ -217,8 +217,9 @@ class ScoreLog extends Model {
       $points,
       $type,
     );
+    await ActivityLog::genCaptureLog($team_id, $level_id);
     self::invalidateMCRecords(); // Invalidate Memcached ScoreLog data.
-    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
     MultiTeam::invalidateMCRecords('ALL_TEAMS'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('POINTS_BY_TYPE'); // Invalidate Memcached MultiTeam data.
     MultiTeam::invalidateMCRecords('LEADERBOARD'); // Invalidate Memcached MultiTeam data.

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -345,7 +345,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
-    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
   }
 
   // Update team password.
@@ -381,7 +381,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
-    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
     await Session::genDeleteByTeam($team_id);
   }
 
@@ -442,7 +442,7 @@ class Team extends Model implements Importable, Exportable {
       $team_id,
     );
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
-    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
   }
 
   // Check if a team name is already created.
@@ -455,6 +455,23 @@ class Team extends Model implements Importable, Exportable {
       'SELECT COUNT(*) FROM teams WHERE name = %s',
       $team_name,
     );
+
+    if ($result->numRows() > 0) {
+      invariant($result->numRows() === 1, 'Expected exactly one result');
+      return (intval(idx($result->mapRows()[0], 'COUNT(*)')) > 0);
+    } else {
+      return false;
+    }
+  }
+
+  // Check if a team name is already created.
+  public static async function genTeamExistById(
+    int $team_id,
+  ): Awaitable<bool> {
+    $db = await self::genDb();
+
+    $result =
+      await $db->queryf('SELECT COUNT(*) FROM teams WHERE id = %d', $team_id);
 
     if ($result->numRows() > 0) {
       invariant($result->numRows() === 1, 'Expected exactly one result');
@@ -608,7 +625,7 @@ class Team extends Model implements Importable, Exportable {
     $db = await self::genDb();
     await $db->queryf('UPDATE teams SET points = 0 WHERE id > 0');
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
-    Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
+    ActivityLog::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached ActivityLog data.
   }
 
   // Teams total number.

--- a/tests/_files/seed.xml
+++ b/tests/_files/seed.xml
@@ -135,6 +135,24 @@
       <value>en</value>
       <value>description</value>
     </row>
+    <row>
+      <value>3</value>
+      <value>game</value>
+      <value></value>
+      <value>description</value>
+    </row>
+    <row>
+      <value>4</value>
+      <value>auto_announce</value>
+      <value>0</value>
+      <value>description</value>
+    </row>
+    <row>
+      <value>5</value>
+      <value>game_paused</value>
+      <value>0</value>
+      <value>description</value>
+    </row>
   </table>
   <table name="categories">
     <column>id</column>

--- a/tests/models/ConfigurationTest.php
+++ b/tests/models/ConfigurationTest.php
@@ -4,7 +4,7 @@ class ConfigurationTest extends FBCTFTest {
 
   public function testAllConfiguration(): void {
     $all = HH\Asio\join(Configuration::genAllConfiguration());
-    $this->assertEquals(2, count($all));
+    $this->assertEquals(5, count($all));
 
     $c = $all[0];
     $this->assertEquals(1, $c->getId());

--- a/tests/models/LevelTest.php
+++ b/tests/models/LevelTest.php
@@ -127,10 +127,10 @@ class LevelTest extends FBCTFTest {
   }
 
   public function testSetStatus(): void {
-    HH\Asio\join(Level::genSetStatus(1, false));
+    HH\Asio\join(Level::genSetStatus(2, false));
     $all = HH\Asio\join(Level::genAllLevels());
     $this->assertEquals(3, count($all));
-    $l = $all[0];
+    $l = $all[1];
     $this->assertFalse($l->getActive());
   }
 


### PR DESCRIPTION
* Dynamically generate activity log and store in the database. Activity log table stores the object type and identifier, so the log is up to date even if some portion of the object has changed (i.e., name).

* Optionally, allow for game related activites to be automatically announced through the announcements area.

* Added table "activity_log" to database.

* Added column "auto_announce" into database configuration table.

* Added auto announcement toggle in admin panel.

* Added auto announcement and activity logging for:
  * Game Start, Pause, Resume, and End
  * Levels being Added, Updated, Enabled, Disabled

* Added activity logging for levels being captured.

* Added ActivityLog class:
  * genCaptureLog() - Stores level capture event in activity log
  * genCreateGameActionLog() - Stores a change to the game state
  * genAdminLog() - Stores administrative action
  * genCreateGenericLog() - Stores generic messages
  * genCreate() - Manually create activity log entry

* Invalidated memcached for relevant level actions.