### PR TITLE
Announcements Controls Rename

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -1112,7 +1112,7 @@ class AdminController extends Controller {
     return
       <div>
         <header class="admin-page-header">
-          <h3>{tr('Game Controls')}</h3>
+          <h3>{tr('Announcement Controls')}</h3>
           <span class="admin-section--status">
             {tr('status_')}<span class="highlighted">{tr('OK')}</span>
           </span>


### PR DESCRIPTION
* Renamed "Game Controls" to "Announcement Controls" on the administrative Announcement page.