### PR TITLE
Set Default Scoring Cache Values

### DIFF
--- a/src/models/MultiTeam.php
+++ b/src/models/MultiTeam.php
@@ -130,6 +130,12 @@ class MultiTeam extends Team {
             );
             $points_by_type->add(Pair {intval($team->get('id')), $type_pair});
           }
+        } else {
+          $type_pair = Map {};
+          $type_pair->add(Pair {'quiz', 0});
+          $type_pair->add(Pair {'flag', 0});
+          $type_pair->add(Pair {'base', 0});
+          $points_by_type->add(Pair {intval($team->get('id')), $type_pair});
         }
       }
       self::setMCRecords('POINTS_BY_TYPE', new Map($points_by_type));


### PR DESCRIPTION
* Before a game begins, or before any scores are captured, the Memcached is empty for multiple scoring values. This results in continual hits to the database.

* Scores are now cached at zero until the first capture is obtained.   This dramatically reduces the number of queries performed and the load on the server.