### PR TITLE
Unique Logos Per Team

### DIFF
--- a/database/logos.sql
+++ b/database/logos.sql
@@ -7,7 +7,7 @@ DROP TABLE IF EXISTS `logos`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `logos` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `used` tinyint(1) DEFAULT 1,
+  `used` tinyint(1) DEFAULT 0,
   `enabled` tinyint(1) DEFAULT 1,
   `protected` tinyint(1) DEFAULT 0,
   `custom` tinyint(1) DEFAULT 0,
@@ -23,7 +23,7 @@ CREATE TABLE `logos` (
 
 LOCK TABLES `logos` WRITE;
 /*!40000 ALTER TABLE `logos` DISABLE KEYS */;
-INSERT INTO `logos` (name, logo, protected, custom) VALUES ('admin', '/static/svg/icons/badges/badge-admin.svg', 1, 0);
+INSERT INTO `logos` (name, logo, protected, used, custom) VALUES ('admin', '/static/svg/icons/badges/badge-admin.svg', 1, 1, 0);
 INSERT INTO `logos` (name, logo, custom) VALUES ('4chan-2', '/static/svg/icons/badges/badge-4chan-2.svg', 0);
 INSERT INTO `logos` (name, logo, custom) VALUES ('4chan', '/static/svg/icons/badges/badge-4chan.svg', 0);
 INSERT INTO `logos` (name, logo, custom) VALUES ('8ball', '/static/svg/icons/badges/badge-8ball.svg', 0);

--- a/src/models/Logo.php
+++ b/src/models/Logo.php
@@ -93,6 +93,20 @@ class Logo extends Model implements Importable, Exportable {
     self::invalidateMCRecords();
   }
 
+  // Set logo as used or unused by passing 1 or 0.
+  public static async function genSetUsed(
+    string $logo_name,
+    bool $used,
+  ): Awaitable<void> {
+    $db = await self::genDb();
+    await $db->queryf(
+      'UPDATE logos SET used = %d WHERE name = %s LIMIT 1',
+      (int) $used,
+      $logo_name,
+    );
+    self::invalidateMCRecords();
+  }
+
   // Retrieve a random logo from the table.
   public static async function genRandomLogo(): Awaitable<string> {
     $all_logos = await self::genAllLogos();
@@ -148,7 +162,7 @@ class Logo extends Model implements Importable, Exportable {
       $all_enabled_logos = array();
       $result =
         await $db->queryf(
-          'SELECT * FROM logos WHERE enabled = 1 AND protected = 0 AND custom = 0',
+          'SELECT * FROM logos WHERE enabled = 1 AND used = 0 AND protected = 0 AND custom = 0',
         );
 
       foreach ($result->mapRows() as $row) {

--- a/src/models/Team.php
+++ b/src/models/Team.php
@@ -99,6 +99,7 @@ class Team extends Model implements Importable, Exportable {
           (bool) must_have_idx($team, 'visible'),
         );
       }
+      await Logo::genSetUsed(must_have_string($team, 'logo'), true);
     }
     return true;
   }
@@ -247,6 +248,8 @@ class Team extends Model implements Importable, Exportable {
       $logo,
     );
 
+    await Logo::genSetUsed($logo, true);
+
     // Return newly created team_id
     $result =
       await $db->queryf(
@@ -256,6 +259,7 @@ class Team extends Model implements Importable, Exportable {
         $logo,
       );
 
+    Logo::invalidateMCRecords();
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
     invariant($result->numRows() === 1, 'Expected exactly one result');
     return intval($result->mapRows()[0]['id']);
@@ -286,6 +290,7 @@ class Team extends Model implements Importable, Exportable {
       $protected ? 1 : 0,
       $visible ? 1 : 0,
     );
+    await Logo::genSetUsed($logo, true);
 
     // Return newly created team_id
     $result =
@@ -296,6 +301,7 @@ class Team extends Model implements Importable, Exportable {
         $logo,
       );
 
+    Logo::invalidateMCRecords();
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
     invariant($result->numRows() === 1, 'Expected exactly one result');
     return intval($result->mapRows()[0]['id']);
@@ -337,6 +343,14 @@ class Team extends Model implements Importable, Exportable {
     int $team_id,
   ): Awaitable<void> {
     $db = await self::genDb();
+
+    // Get and set old logo to unused
+    $result =
+      await $db->queryf('SELECT logo FROM teams WHERE id = %d', $team_id);
+    invariant($result->numRows() === 1, 'Expected exactly one result');
+    $logo_old = strval($result->mapRows()[0]['logo']);
+    await Logo::genSetUsed($logo_old, false);
+
     await $db->queryf(
       'UPDATE teams SET name = %s, logo = %s , points = %d WHERE id = %d LIMIT 1',
       $name,
@@ -344,6 +358,9 @@ class Team extends Model implements Importable, Exportable {
       $points,
       $team_id,
     );
+    await Logo::genSetUsed($logo, true);
+
+    Logo::invalidateMCRecords();
     MultiTeam::invalidateMCRecords(); // Invalidate Memcached MultiTeam data.
     Control::invalidateMCRecords('ALL_ACTIVITY'); // Invalidate Memcached Control data.
   }
@@ -366,6 +383,12 @@ class Team extends Model implements Importable, Exportable {
   // Delete team.
   public static async function genDelete(int $team_id): Awaitable<void> {
     $db = await self::genDb();
+    $result =
+      await $db->queryf('SELECT logo FROM teams WHERE id = %d', $team_id);
+    invariant($result->numRows() === 1, 'Expected exactly one result');
+    $logo = strval($result->mapRows()[0]['logo']);
+    await Logo::genSetUsed($logo, false);
+
     await $db->queryf(
       'DELETE FROM teams WHERE id = %d AND protected = 0 LIMIT 1',
       $team_id,


### PR DESCRIPTION
* Functionality prevents users from utilizing the same logo as another user/team or one already in use.

* Users now are provided the option of selecting a unique, or unused logo.

* When a logo is selected the logo is marked as used.

* When a logo is removed from a team (through team deletion, logo change, or otherwise) the logo is readded to the rotation for available logos.

* When a team is imported their logo is set to used.

* Database schema changed to set the default for all logos to unused. The scheme update also sets the admin logo to used.