### PR TITLE
Custom Branding Update

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -232,7 +232,8 @@ INSERT INTO `configuration` (field, value, description) VALUES("language", "en",
 INSERT INTO `configuration` (field, value, description) VALUES("livesync", "0", "(Boolean) LiveSync functionality");
 INSERT INTO `configuration` (field, value, description) VALUES("livesync_auth_key", "", "(String) Optional LiveSync Auth Key");
 INSERT INTO `configuration` (field, value, description) VALUES("custom_logo", "0", "(Boolean) Custom branding logo");
-INSERT INTO `configuration` (field, value, description) VALUES("custom_text", "Powered By Facebook", "(String) Custom branding text");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_org", "Facebook", "(String) Custom branding organization text");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_byline", "Powered By Facebook", "(String) Custom branding byline text");
 INSERT INTO `configuration` (field, value, description) VALUES("custom_logo_image", "static/img/favicon.png", "(String) Custom logo image file");
 UNLOCK TABLES;
 

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -231,6 +231,10 @@ INSERT INTO `configuration` (field, value, description) VALUES("default_bonusdec
 INSERT INTO `configuration` (field, value, description) VALUES("language", "en", "(String) Language of the system");
 INSERT INTO `configuration` (field, value, description) VALUES("livesync", "0", "(Boolean) LiveSync functionality");
 INSERT INTO `configuration` (field, value, description) VALUES("livesync_auth_key", "", "(String) Optional LiveSync Auth Key");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_logo", "0", "(Boolean) Custom branding logo");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_org", "Facebook", "(String) Custom branding organization text");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_byline", "Powered By Facebook", "(String) Custom branding byline text");
+INSERT INTO `configuration` (field, value, description) VALUES("custom_logo_image", "static/img/favicon.png", "(String) Custom logo image file");
 UNLOCK TABLES;
 
 --

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -3,7 +3,8 @@
 class AdminController extends Controller {
   <<__Override>>
   protected function getTitle(): string {
-    return tr('Facebook CTF').' | '.tr('Admin');
+    $custom_org = \HH\Asio\join(Configuration::gen('custom_org'));
+    return tr($custom_org->getValue()). ' '. tr('CTF'). ' | '. tr('Admin');
   }
 
   <<__Override>>
@@ -315,7 +316,8 @@ class AdminController extends Controller {
       'livesync' => Configuration::gen('livesync'),
       'livesync_auth_key' => Configuration::gen('livesync_auth_key'),
       'custom_logo' => Configuration::gen('custom_logo'),
-      'custom_text' => Configuration::gen('custom_text'),
+      'custom_org' => Configuration::gen('custom_org'),
+      'custom_byline' => Configuration::gen('custom_byline'),
       'custom_logo_image' => Configuration::gen('custom_logo_image'),
     };
 
@@ -345,7 +347,8 @@ class AdminController extends Controller {
     $livesync = $results['livesync'];
     $livesync_auth_key = $results['livesync_auth_key'];
     $custom_logo = $results['custom_logo'];
-    $custom_text = $results['custom_text'];
+    $custom_org = $results['custom_org'];
+    $custom_byline = $results['custom_byline'];
     $custom_logo_image = $results['custom_logo_image'];
 
     $registration_on = $registration->getValue() === '1';
@@ -1047,11 +1050,21 @@ class AdminController extends Controller {
                   </div>
                   <div class="col col-pad col-1-3">
                     <div class="form-el el--block-label el--full-text">
-                      <label for="">{tr('Custom Text')}</label>
+                      <label for="">{tr('Custom Organization')}</label>
                       <input
                         type="text"
-                        name="fb--conf--custom_text"
-                        value={$custom_text->getValue()}
+                        name="fb--conf--custom_org"
+                        value={$custom_org->getValue()}
+                      />
+                    </div>
+                  </div>
+                  <div class="col col-pad col-1-3">
+                    <div class="form-el el--block-label el--full-text">
+                      <label for="">{tr('Custom Byline')}</label>
+                      <input
+                        type="text"
+                        name="fb--conf--custom_byline"
+                        value={$custom_byline->getValue()}
                       />
                     </div>
                   </div>

--- a/src/controllers/Controller.php
+++ b/src/controllers/Controller.php
@@ -10,22 +10,22 @@ abstract class Controller {
   public async function genRenderBranding(): Awaitable<:xhp> {
     $awaitables = Map {
       'custom_logo' => Configuration::gen('custom_logo'),
-      'custom_text' => Configuration::gen('custom_text'),
+      'custom_byline' => Configuration::gen('custom_byline'),
       'custom_logo_image' => Configuration::gen('custom_logo_image'),
     };
     $results = await \HH\Asio\m($awaitables);
     $branding = $results['custom_logo'];
-    $custom_text = $results['custom_text'];
+    $custom_byline = $results['custom_byline'];
     if ($branding->getValue() === '0') {
       $branding_xhp = 
         <fbbranding
-          brandingText={tr(strval($custom_text->getValue()))}
+          brandingText={tr(strval($custom_byline->getValue()))}
         />;
     } else {
       $custom_logo_image = $results['custom_logo_image'];
       $branding_xhp = 
         <custombranding
-          brandingText={strval($custom_text->getValue())}
+          brandingText={strval($custom_byline->getValue())}
           brandingLogo={strval($custom_logo_image->getValue())}
         />;
     }

--- a/src/controllers/GameboardController.php
+++ b/src/controllers/GameboardController.php
@@ -3,7 +3,8 @@
 class GameboardController extends Controller {
   <<__Override>>
   protected function getTitle(): string {
-    return tr('Facebook CTF').' | '.tr('Gameboard');
+    $custom_org = \HH\Asio\join(Configuration::gen('custom_org'));
+    return tr($custom_org->getValue()). ' '. tr('CTF').' | '.tr('Gameboard');
   }
 
   <<__Override>>

--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -2,8 +2,9 @@
 
 class IndexController extends Controller {
   <<__Override>>
-  protected function getTitle(): string {
-    return tr('Facebook CTF');
+  public function getTitle(): string {
+    $custom_org = \HH\Asio\join(Configuration::gen('custom_org'));
+    return tr($custom_org->getValue()). ' '. tr('CTF');
   }
 
   <<__Override>>
@@ -38,6 +39,12 @@ class IndexController extends Controller {
   }
 
   public function renderMainContent(): :xhp {
+    $custom_org = \HH\Asio\join(Configuration::gen('custom_org'));
+    if ($custom_org->getValue() === 'Facebook') {
+      $welcome_msg = tr('Welcome to the Facebook Capture the Flag Competition. By clicking "Play," you will be entered into the official CTF challenge. Good luck in your conquest.');
+    } else {
+      $welcome_msg = 'Welcome to the ' . $custom_org->getValue() . ' Capture the Flag Competition. By clicking "Play," you will be entered into the official CTF challenge. Good luck in your conquest.';
+    }
     return
       <div class="fb-row-container full-height fb-scroll">
         <main
@@ -49,9 +56,7 @@ class IndexController extends Controller {
               {tr('Conquer the world')}
             </h1>
             <p class="typed-text">
-              {tr(
-                'Welcome to the Facebook Capture the Flag Competition. By clicking "Play," you will be entered into the official CTF challenge. Good luck in your conquest.',
-              )}
+              {$welcome_msg}
             </p>
             <div class="fb-actionable">
               <a href="/index.php?page=countdown" class="fb-cta cta--yellow">

--- a/src/controllers/ViewModeController.php
+++ b/src/controllers/ViewModeController.php
@@ -3,7 +3,8 @@
 class ViewModeController extends Controller {
   <<__Override>>
   protected function getTitle(): string {
-    return tr('Facebook CTF').' | '.tr('View mode');
+    $custom_org = \HH\Asio\join(Configuration::gen('custom_org'));
+    return tr($custom_org->getValue()).' | '.tr('View mode');
   }
 
   <<__Override>>


### PR DESCRIPTION
* Added "Custom Organization," editable within the administrative interface. The organization will display the system name (i.e., "Custom CTF") in all relevant locations including the page titles.

* Custom Text has been renamed to "Custom Byline."

* The custom organization value will also be used for the welcome message on the landing page.

* Database updated to support the new customization options.