### PR TITLE
Downgraded DropkickJS and Streamlined Provision for NodeJS/Downloads (Fixes: #554)

### DIFF
--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -214,7 +214,6 @@ package_repo_update
 
 package git
 package curl
-package wget
 package rsync
 
 # Check for available memory, should be over 1GB
@@ -307,18 +306,8 @@ fi
         fi
 
         package ca-certificates
-        package npm
-        log "Updating npm"
-        sudo npm install -g npm@lts
 
-        log "Removing node.js legacy version"
-        sudo DEBIAN_FRONTEND=noninteractive apt-get remove --purge nodejs -y
-
-        log "Downloading updated node.js version"
-        curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-
-        log "Installing node.js"
-        package nodejs
+        install_nodejs
 
         log "Installing all required npm node_modules"
         sudo npm install --prefix "$CTF_PATH"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "d3": "^3.5.16",
-    "dropkickjs": "^2.1.10",
+    "dropkickjs": "2.1.10",
     "hoverintent-jqplugin": "^0.2.1",
     "jquery": "^2.2.3",
     "keycode": "^2.1.1",


### PR DESCRIPTION
* Downgraded Dropkick.js to version 2.1.10.  The project originally was built using 2.1.10 and specified a near version in the 2.x.x release family.  On August 27th 2017 Dropkick.js released version 2.2.0 which is incompatible with ES6 specs. The incompatibility with the new release of Dropkick.js caused the provisioning of the platform to fail.

* Moved the installation process for Node.js to a function within `lib.sh`.  This change streamlines the provision script.

* Removed the installation of `wget` from provisioning.  `wget` is no longer used within the project and is therefore unneeded.

* Updated the `dl()` download function within the provision script to use `curl` exclusively, with retry options.  The retry options are set to 5 retries with a 15-second delay between retries.  The addition of the retry option ensures the provision can continue if there is a temporary issue with a remote connection or availability of a remote resource.

* Added the `dl_pipe()` download function to the provision script.  This download function provided the data from the remote resource via standard output to be piped into another command.  As piping downloads within the provisioning process have become more common, this function streamlines the process.

* Fixes #554 

* Updates fixes for #550