### PR TITLE
Optimization of connections and database

### DIFF
--- a/database/countries.sql
+++ b/database/countries.sql
@@ -12,7 +12,9 @@ CREATE TABLE `countries` (
   `enabled` tinyint(1) DEFAULT 0,
   `d` text DEFAULT NULL,
   `transform` text DEFAULT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `iso_code` (`iso_code`),
+  KEY `enabled` (`enabled`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE `levels` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `active` tinyint(1) NOT NULL,
   `type` varchar(4) NOT NULL,
-  `title` text NOT NULL,
+  `title` varchar(255) NOT NULL,
   `description` text NOT NULL,
   `entity_id` int(11) NOT NULL,
   `category_id` int(11) NOT NULL,
@@ -48,7 +48,9 @@ CREATE TABLE `levels` (
   `hint` text NOT NULL,
   `penalty` int(11) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `entity_id` (`entity_id`),
+  KEY `active` (`active`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -61,7 +63,7 @@ DROP TABLE IF EXISTS `categories`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `categories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `category` text NOT NULL,
+  `category` varchar(255) NOT NULL,
   `protected` tinyint(1) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
@@ -116,8 +118,8 @@ DROP TABLE IF EXISTS `teams`;
 CREATE TABLE `teams` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `active` tinyint(1) NOT NULL DEFAULT 1,
-  `name` text NOT NULL,
-  `password_hash` text NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `password_hash` varchar(255) NOT NULL,
   `points` int(11) NOT NULL DEFAULT 0,
   `last_score` timestamp NOT NULL,
   `logo` text NOT NULL,
@@ -125,7 +127,9 @@ CREATE TABLE `teams` (
   `protected` tinyint(1) NOT NULL DEFAULT 0,
   `visible` tinyint(1) NOT NULL DEFAULT 1,
   `created_ts` timestamp NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `visible` (`visible`),
+  KEY `active` (`active`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -157,9 +161,10 @@ CREATE TABLE `teams_data` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `team_id` int(11) NOT NULL,
   `name` text NOT NULL,
-  `email` text NOT NULL,
+  `email` varchar(255) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `team_id` (`team_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -172,13 +177,14 @@ DROP TABLE IF EXISTS `sessions`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sessions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `cookie` text NOT NULL,
+  `cookie` varchar(200) NOT NULL,
   `data` text NOT NULL,
   `team_id` int(11) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   `last_access_ts` timestamp NOT NULL,
-  `last_page_access` text NOT NULL,
-  PRIMARY KEY (`id`)
+  `last_page_access` varchar(200) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `cookie` (`cookie`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -291,12 +297,13 @@ DROP TABLE IF EXISTS `registration_tokens`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registration_tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `token` text NOT NULL,
+  `token` varchar(250) NOT NULL,
   `used` tinyint(1) NOT NULL,
   `team_id` int(11) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   `use_ts` timestamp NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `token` (`token`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -314,7 +321,9 @@ CREATE TABLE `scores_log` (
   `points` int(11) NOT NULL,
   `level_id` int(11) NOT NULL,
   `type` varchar(4) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `level_id` (`level_id`),
+  KEY `team_id` (`team_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -331,7 +340,8 @@ CREATE TABLE `bases_log` (
   `code` int(11) NOT NULL,
   `response` text NOT NULL,
   `level_id` int(11) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `level_id` (`level_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -346,10 +356,12 @@ CREATE TABLE `scripts` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `ts` timestamp NULL,
   `pid` int(11) NOT NULL,
-  `name` text NOT NULL,
+  `name` varchar(255) NOT NULL,
   `cmd` text NOT NULL,
   `status` tinyint(1) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `status` (`status`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -366,7 +378,9 @@ CREATE TABLE `failures_log` (
   `team_id` int(11) NOT NULL,
   `level_id` int(11) NOT NULL,
   `flag` text NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `team_id` (`team_id`),
+  KEY `level_id` (`level_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -383,7 +397,9 @@ CREATE TABLE `hints_log` (
   `level_id` int(11) NOT NULL,
   `team_id` int(11) NOT NULL,
   `penalty` int(11) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `level_id` (`level_id`),
+  KEY `team_id` (`team_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/database/test_schema.sql
+++ b/database/test_schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE `levels` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `active` tinyint(1) NOT NULL,
   `type` varchar(4) NOT NULL,
-  `title` text NOT NULL,
+  `title` varchar(255) NOT NULL DEFAULT '',
   `description` text NOT NULL,
   `entity_id` int(11) NOT NULL,
   `category_id` int(11) NOT NULL,
@@ -47,9 +47,11 @@ CREATE TABLE `levels` (
   `flag` text NOT NULL,
   `hint` text NOT NULL,
   `penalty` int(11) NOT NULL,
-  `created_ts` timestamp NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+  `created_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `entity_id` (`entity_id`),
+  KEY `active` (`active`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -61,7 +63,7 @@ DROP TABLE IF EXISTS `categories`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `categories` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `category` text NOT NULL,
+  `category` varchar(255) NOT NULL,
   `protected` tinyint(1) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
@@ -116,7 +118,7 @@ DROP TABLE IF EXISTS `teams`;
 CREATE TABLE `teams` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `active` tinyint(1) NOT NULL DEFAULT 1,
-  `name` text NOT NULL,
+  `name` varchar(255) NOT NULL,
   `password_hash` text NOT NULL,
   `points` int(11) NOT NULL DEFAULT 0,
   `last_score` timestamp NOT NULL,
@@ -125,7 +127,9 @@ CREATE TABLE `teams` (
   `protected` tinyint(1) NOT NULL DEFAULT 0,
   `visible` tinyint(1) NOT NULL DEFAULT 1,
   `created_ts` timestamp NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `visible` (`visible`),
+  KEY `active` (`active`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -156,10 +160,11 @@ DROP TABLE IF EXISTS `teams_data`;
 CREATE TABLE `teams_data` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `team_id` int(11) NOT NULL,
-  `name` text NOT NULL,
-  `email` text NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `team_id` (`team_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -172,14 +177,15 @@ DROP TABLE IF EXISTS `sessions`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `sessions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `cookie` text NOT NULL,
+  `cookie` varchar(200) NOT NULL,
   `data` text NOT NULL,
   `team_id` int(11) NOT NULL,
-  `created_ts` timestamp NOT NULL DEFAULT 0,
-  `last_access_ts` timestamp NOT NULL,
-  `last_page_access` text NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+  `created_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_access_ts` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_page_access` varchar(200) NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  KEY `cookie` (`cookie`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -291,12 +297,13 @@ DROP TABLE IF EXISTS `registration_tokens`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `registration_tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `token` text NOT NULL,
+  `token` varchar(250) NOT NULL,
   `used` tinyint(1) NOT NULL,
   `team_id` int(11) NOT NULL,
   `created_ts` timestamp NOT NULL DEFAULT 0,
   `use_ts` timestamp NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `token` (`token`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -314,7 +321,9 @@ CREATE TABLE `scores_log` (
   `points` int(11) NOT NULL,
   `level_id` int(11) NOT NULL,
   `type` varchar(4) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `level_id` (`level_id`),
+  KEY `team_id` (`team_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -331,7 +340,8 @@ CREATE TABLE `bases_log` (
   `code` int(11) NOT NULL,
   `response` text NOT NULL,
   `level_id` int(11) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `level_id` (`level_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -366,7 +376,9 @@ CREATE TABLE `failures_log` (
   `team_id` int(11) NOT NULL,
   `level_id` int(11) NOT NULL,
   `flag` text NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `team_id` (`team_id`),
+  KEY `level_id` (`level_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -383,7 +395,9 @@ CREATE TABLE `hints_log` (
   `level_id` int(11) NOT NULL,
   `team_id` int(11) NOT NULL,
   `penalty` int(11) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `level_id` (`level_id`),
+  KEY `team_id` (`team_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/extra/hhvm.conf
+++ b/extra/hhvm.conf
@@ -24,3 +24,12 @@ hhvm.repo.central.path = /var/run/hhvm/hhvm.hhbc
 hhvm.mysql.socket = /var/run/mysqld/mysqld.sock
 hhvm.pdo_mysql.socket = /var/run/mysqld/mysqld.sock
 hhvm.mysqli.socket = /var/run/mysqld/mysqld.sock
+
+# MySQL Optimization
+# Use persistent connections and higher timeout
+mysqli.reconnect = 1
+mysqli.allow_persistent = On
+mysqli.max_persistent = 400
+hhvm.mysql.connect_timeout = 1500
+hhvm.mysql.read_timeout = 2000
+hhvm.mysql.max_retry_open_on_fail = 3

--- a/src/Db.php
+++ b/src/Db.php
@@ -17,8 +17,10 @@ class Db {
   private function __construct() {
     $this->config = parse_ini_file($this->settings_file);
     $options = array(
-      'idle_timeout_micros' => 200000,
+      'idle_timeout_micros' => 2000000,
       'expiration_policy' => 'IdleTime',
+      'per_key_connection_limit' => 20,
+      'pool_connection_limit' => 20
     );
     $this->pool = new AsyncMysqlConnectionPool($options);
   }


### PR DESCRIPTION
Hello, this pull request should improve the database schema and making correct use of database types (For example session and use of INDEX [#548]).

In HHVM the pool of MySQL connections is created by request, which is now opening between 5 and 15 connections depending on the section. This generated a big overhead to the database, which will result in max_allowed_connections errors with 50 concurrent users.

Changing the idle timeout of pool from 0.2 to 2 seconds will result in reutilization of connections instead of generating new ones and 20 max connections to make sure the db is not stressed (Default is 50).

Let me know if have any questions!