### PR TITLE
Travis-CI to use Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
-# We use language generic because that's the only thing that's supported for the
-# trusty distro
-language: generic
+# We are now using Docker to test builds with Travis - this removes our dependency on Ubuntu 14.04
 sudo: required
-dist: trusty
+language: generic
 
-group: deprecated-2017Q2
+services:
+ - docker
 
-install: ./extra/provision.sh -m dev -s $TRAVIS_BUILD_DIR -d $TRAVIS_BUILD_DIR
+install:
+ - docker build --build-arg MODE=dev -t="fbctf_in_travis" .
 
-script: ./extra/run_tests.sh $TRAVIS_BUILD_DIR
+script:
+ - docker run -d -p 80:80 -p 443:443 --name="fbctf_in_travis" fbctf_in_travis
+ - docker exec fbctf_in_travis /var/www/fbctf/extra/run_tests.sh /var/www/fbctf/

--- a/extra/run_tests.sh
+++ b/extra/run_tests.sh
@@ -12,6 +12,34 @@ CODE_PATH=${1:-/vagrant}
 DB_USER=${2:-root}
 DB_PWD=${3:-root}
 
+echo "[+] Verifying service status"
+READY=0
+for i in {1..10}; do
+  HHVM_STATUS=$(service hhvm status | grep -P "start|running|Uptime" | wc -l)
+  NGINX_STATUS=$(service nginx status | grep -P "start|running|Uptime" | wc -l)
+  MYSQL_STATUS=$(service mysql status | grep -P "start|running|Uptime" | wc -l)
+  MC_STATUS=$(service memcached status | grep -P "start|running|Uptime" | wc -l)
+  if [ $HHVM_STATUS == 0 ] || [ $NGINX_STATUS == 0 ] || [ $MYSQL_STATUS == 0 ] || [ $MC_STATUS == 0 ]; then
+    echo "[+] Services not ready, waiting 10 seconds..."
+    sleep 10
+    continue
+  else
+    READY=1
+    break
+  fi
+done
+
+if [ $READY = 0 ]; then
+  echo "[!] Services are not running, tests cannot be completed."
+  exit 1
+else
+  echo "[+] Services are running"
+fi
+
+
+echo "[+] Changing directory to $CODE_PATH"
+cd "$CODE_PATH"
+
 echo "[+] Starting tests setup in $CODE_PATH"
 
 mysql -u "$DB_USER" --password="$DB_PWD" -e "CREATE DATABASE $DB;"


### PR DESCRIPTION
* Travis-CI now builds a docker image and uses the docker image for build testing.

* Split docker build, docker run, and the docker execution of `run_tests.sh` into separate steps.

* Added a service status check to `run_tests.sh` to ensure services are running or wait until they are.  The service test process will not directly return any error status; instead, the process will wait (up to 10 times, 10 seconds each) for the services to come online before finally failing with an error or continuing if everything is ready.

* This change removes our dependency on Travis-provided images and allows us to move away from Ubuntu 14.04 when ready.