### PR TITLE
Ensure /root/tmp exists before writing there

### DIFF
--- a/extra/lib.sh
+++ b/extra/lib.sh
@@ -128,6 +128,7 @@ function letsencrypt_cert() {
   fi
 
   if [[ "$__docker" = true ]]; then
+    mkdir -p /root/tmp
     cat <<- EOF > /root/tmp/certbot.sh
 		#!/bin/bash
 		if [[ ! ( -d /etc/letsencrypt && "\$(ls -A /etc/letsencrypt)" ) ]]; then


### PR DESCRIPTION
When running `docker-compose build nginx` in production mode, the following error is raised:

```bash
[+] Installing nginx and certificates
[+] Deploying certificates
Generating a 2048 bit RSA private key
..............+++
...........+++
writing new private key to '/etc/nginx/certs/fbctf.key'
-----
Signature ok
subject=/O=Facebook CTF
Getting Private key
/root/extra/lib.sh: line 131: /root/tmp/certbot.sh: No such file or directory
ERROR: Service 'nginx' failed to build: The command '/bin/sh -c ./extra/provision.sh -m $MODE -c $TYPE -k $KEY -C $CRT -D $DOMAIN -e $EMAIL -s `pwd` --docker --multiple-servers --server-type nginx --hhvm-server hhvm' returned a non-zero code: 1
```

When we ensure that the `/root/tmp` directory exists before writing the `certbot.sh` script into it, everything works fine:

```bash
Step 14/14 : CMD ./extra/nginx/nginx_startup.sh
 ---> Running in 77526114e55d
 ---> 17dff811ce47
Removing intermediate container 77526114e55d
Successfully built 17dff811ce47
``` 