### PR TITLE
Changing teamname into team_name

### DIFF
--- a/src/controllers/IndexController.php
+++ b/src/controllers/IndexController.php
@@ -347,7 +347,7 @@ class IndexController extends Controller {
                 <label for="">{tr('Team Name')}</label>
                 <input
                   autocomplete="off"
-                  name="teamname"
+                  name="team_name"
                   type="text"
                   maxlength={20}
                   autofocus={true}
@@ -454,7 +454,7 @@ class IndexController extends Controller {
                 <label for="">{tr('Team Name')}</label>
                 <input
                   autocomplete="off"
-                  name="teamname"
+                  name="team_name"
                   type="text"
                   maxlength={20}
                   autofocus={true}


### PR DESCRIPTION
Bug in signing up new users due to a typo in the teamname element. Related to https://github.com/facebook/fbctf/commit/1a8286bef5d124e85e48bb281a00cfd5477152f2

Without this, verifyTeamname (https://github.com/asudhak/fbctf/blob/dev/src/static/js/index.js#L46) during user sign up will fail because there is not element called 'team_name'