### PR TITLE
Fix scoreboard graph for new registrations

### DIFF
--- a/src/data/scores.php
+++ b/src/data/scores.php
@@ -14,14 +14,12 @@ class ScoresDataController extends DataController {
     $leaderboard = await MultiTeam::genLeaderboard(false);
     foreach ($leaderboard as $team) {
       $values = array();
-      $i = 1;
       $progressive_scoreboard =
         await Progressive::genProgressiveScoreboard($team->getName()); // TODO: Combine Awaits
       foreach ($progressive_scoreboard as $progress) {
         $score =
-          (object) array('time' => $i, 'score' => $progress->getPoints());
+          (object) array('time' => $progress->getIteration(), 'score' => $progress->getPoints());
         array_push($values, $score);
-        $i++;
       }
       $color = substr(md5($team->getName()), 0, 6);
       $element = (object) array(


### PR DESCRIPTION
If a team registered after the game had started, their line would still start at the beginning of the graph, ending somewhere in the middle. Making the data use the iteration, rather than an arbitrary count, moves it to the proper temporal location.