### PR TITLE
Background script logging + fix autorun launching scripts

### DIFF
--- a/extra/provision.sh
+++ b/extra/provision.sh
@@ -60,6 +60,7 @@ DOMAIN="none"
 EMAIL="none"
 CODE_PATH="/vagrant"
 CTF_PATH="/var/www/fbctf"
+LOG_PATH="/var/log/fbctf"
 HHVM_CONFIG_PATH="/etc/hhvm/server.ini"
 DOCKER=false
 MULTIPLE_SERVERS=false
@@ -332,6 +333,10 @@ fi
     log "Creating custom logos folder, and setting ownership to www-data"
     sudo mkdir -p "$CTF_PATH/src/data/customlogos"
     sudo chown -R www-data:www-data "$CTF_PATH/src/data/customlogos"
+
+    log "Creating scripts log folder, and setting ownership to www-data"
+    sudo mkdir -p "$LOG_PATH"
+    sudo chown -R www-data:www-data "$LOG_PATH"
 fi
 
 # If multiple servers are being utilized, ensure provision was called from the "cache" server

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -108,6 +108,10 @@ class Utils {
     return new Map($_FILES);
   }
 
+  public static function get_src_root() : string {
+    return preg_replace(':/src/.*$:', '/src', __DIR__);
+  }
+
   public static function redirect(string $location): void {
     header('Location: '.$location);
   }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -140,4 +140,21 @@ class Utils {
   ): string {
     return self::request_response('ERROR', $msg, $redirect);
   }
+
+  public static function logMessage(
+    string $message
+  ): void {
+    $date = date('m/d/Y h:i:s a', time());
+    $message = "[$date] $message\n";
+
+    if (php_sapi_name() === 'cli') {
+      fwrite(STDOUT, $message);
+    } else {
+      $filename = '/var/log/fbctf/web.log';
+      if ($handle = fopen($filename, 'a')) {
+        fwrite($handle, $message);
+        fclose($handle);
+      }
+    }
+  }
 }

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -1283,11 +1283,13 @@ class Level extends Model implements Importable, Exportable {
 
   // Bases processing and scoring.
   public static async function genBaseScoring(): Awaitable<void> {
+    Utils::logMessage('Starting background script: bases');
     $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
     $cmd =
       'hhvm -vRepo.Central.Path=/var/run/hhvm/.hhvm.hhbc_bases '.
       $document_root.
-      '/scripts/bases.php > /dev/null 2>&1 & echo $!';
+      '/scripts/bases.php >> /var/log/fbctf/bases.log 2>&1 & echo $!';
+    Utils::logMessage("Using command: [$cmd]");
     $pid = shell_exec($cmd);
     await Control::genStartScriptLog(intval($pid), 'bases', $cmd);
   }

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -1284,7 +1284,7 @@ class Level extends Model implements Importable, Exportable {
   // Bases processing and scoring.
   public static async function genBaseScoring(): Awaitable<void> {
     Utils::logMessage('Starting background script: bases');
-    $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
+    $document_root = Utils::get_src_root();
     $cmd =
       'hhvm -vRepo.Central.Path=/var/run/hhvm/.hhvm.hhbc_bases '.
       $document_root.

--- a/src/models/Progressive.php
+++ b/src/models/Progressive.php
@@ -146,11 +146,13 @@ class Progressive extends Model {
 
   // Kick off the progressive scoreboard in the background.
   public static async function genRun(): Awaitable<void> {
+    Utils::logMessage('Starting background script: progressive scoreboard');
     $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
     $cmd =
       'hhvm -vRepo.Central.Path=/var/run/hhvm/.hhvm.hhbc_progressive '.
       $document_root.
-      '/scripts/progressive.php > /dev/null 2>&1 & echo $!';
+      "/scripts/progressive.php >> /var/log/fbctf/progressive.log 2>&1 & echo $!";
+    Utils::logMessage("Using command: [$cmd]");
     $pid = shell_exec($cmd);
     await Control::genStartScriptLog(intval($pid), 'progressive', $cmd);
   }

--- a/src/models/Progressive.php
+++ b/src/models/Progressive.php
@@ -147,7 +147,7 @@ class Progressive extends Model {
   // Kick off the progressive scoreboard in the background.
   public static async function genRun(): Awaitable<void> {
     Utils::logMessage('Starting background script: progressive scoreboard');
-    $document_root = must_have_string(Utils::getSERVER(), 'DOCUMENT_ROOT');
+    $document_root = Utils::get_src_root();
     $cmd =
       'hhvm -vRepo.Central.Path=/var/run/hhvm/.hhvm.hhbc_progressive '.
       $document_root.

--- a/src/scripts/autorun.php
+++ b/src/scripts/autorun.php
@@ -23,6 +23,8 @@ require_once (__DIR__.'/../models/FailureLog.php');
 require_once (__DIR__.'/../models/Announcement.php');
 require_once (__DIR__.'/../models/ActivityLog.php');
 
+Utils::logMessage('Starting autorun');
+
 while (1) {
   \HH\Asio\join(Control::genAutoRun());
 

--- a/src/scripts/bases.php
+++ b/src/scripts/bases.php
@@ -23,6 +23,8 @@ require_once (__DIR__.'/../models/ActivityLog.php');
 
 $conf_game = \HH\Asio\join(Configuration::gen('game'));
 while ($conf_game->getValue() === '1') {
+  Utils::logMessage('Fetching base endpoints');
+
   // Get all active base levels
   $bases_endpoints = array();
   foreach (\HH\Asio\join(Level::genAllActiveBases()) as $base) {
@@ -30,6 +32,7 @@ while ($conf_game->getValue() === '1') {
       'id' => $base->getId(),
       'url' => \HH\Asio\join(Level::genBaseIP($base->getId())),
     );
+    Utils::logMessage("Adding endpoint to call for level ${endpoint['id']}: ${endpoint['url']}");
     array_push($bases_endpoints, $endpoint);
   }
 
@@ -45,10 +48,10 @@ while ($conf_game->getValue() === '1') {
         \HH\Asio\join(Level::genScoreBase($response['id'], $team->getId()));
         //echo "Points\n";
       }
-      //echo "Base(".strval($response['id']).") taken by ".$team_name."\n";
+      Utils::logMessage("Base(".strval($response['id']).") taken by $team_name.");
     } else {
       $code = -1;
-      //echo "Base(".strval($response['id']).") is DOWN\n";
+      Utils::logMessage("Base(".strval($response['id']).") is DOWN");
     }
     \HH\Asio\join(
       Level::genLogBaseEntry(
@@ -60,7 +63,9 @@ while ($conf_game->getValue() === '1') {
   }
   // Wait until next iteration
   $bases_cycle = \HH\Asio\join(Configuration::gen('bases_cycle'));
-  sleep(intval($bases_cycle->getValue()));
+  $sleep_length = $bases_cycle->getValue();
+  Utils::logMessage("Sleeping for $sleep_length seconds");
+  sleep(intval($sleep_length));
 
   // Flush the local cache before the next cycle to ensure the game is still running and the configuration of the bases hasn't changed (the script runs continuously).
   Model::deleteLocalCache();
@@ -68,3 +73,4 @@ while ($conf_game->getValue() === '1') {
   // Get current game status
   $conf_game = \HH\Asio\join(Configuration::gen('game'));
 }
+Utils::logMessage('Game is no longer running. Shutting down.');

--- a/src/scripts/liveimport.php
+++ b/src/scripts/liveimport.php
@@ -597,8 +597,11 @@ class LiveSyncImport {
     string $indicator,
     string $message,
   ): void {
+    $msg = "[".date('D M j G:i:s Y')."] [$url] $indicator $message\n";
     if ($debug === true) {
-      print "[".date('D M j G:i:s Y')."] [$url] $indicator $message\n";
+      print $msg;
+    } else {
+      Utils::logMessage($msg);
     }
   }
 }

--- a/src/scripts/progressive.php
+++ b/src/scripts/progressive.php
@@ -12,6 +12,8 @@ require_once (__DIR__.'/../models/Configuration.php');
 require_once (__DIR__.'/../models/Progressive.php');
 
 while (\HH\Asio\join(Progressive::genGameStatus())) {
+  Utils::logMessage('Progressive scoreboard cycling');
   \HH\Asio\join(Progressive::genTake());
   sleep(\HH\Asio\join(Progressive::genCycle()));
 }
+Utils::logMessage('Game is no longer running. Shutting down.');


### PR DESCRIPTION
- Create a logging directory at `/var/log/fbctf`
- Redirect STDOUT and STDERR to an appropriate log file
- When the log function is called in a web request, write to a generic web log file
- Log when the game starts & ends
- Log when the scripts are starting
- Use correct script paths when launching via autorun
  - Found out that this was why the scripts weren't running as a result of adding the logging