### PR TITLE
Base improvements

### DIFF
--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -2540,13 +2540,13 @@ class AdminController extends Controller {
                   <div
                     class=
                       "form-el--required col col-1-2 el--block-label el--full-text">
-                    <label>{tr('Keep Points')}</label>
+                    <label>{tr('Capture Points')}</label>
                     <input name="points" type="text" />
                   </div>
                   <div
                     class=
                       "form-el--required col col-1-2 el--block-label el--full-text">
-                    <label>{tr('Capture points')}</label>
+                    <label>{tr('Keep points')}</label>
                     <input name="bonus" type="text" />
                   </div>
                 </div>

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -2894,7 +2894,7 @@ class AdminController extends Controller {
                   <div
                     class=
                       "form-el--required col col-1-2 el--block-label el--full-text">
-                    <label>{tr('Points')}</label>
+                    <label>{tr('Capture Points')}</label>
                     <input
                       name="points"
                       type="text"
@@ -2903,7 +2903,7 @@ class AdminController extends Controller {
                     />
                   </div>
                   <div class="col col-1-2 el--block-label el--full-text">
-                    <label>{tr('Bonus')}</label>
+                    <label>{tr('Keep points')}</label>
                     <input
                       name="bonus"
                       type="text"

--- a/src/controllers/modals/CountryModalController.php
+++ b/src/controllers/modals/CountryModalController.php
@@ -145,6 +145,12 @@ class CountryModalController extends ModalController {
                   <div class="points-display">
                     <span class="points-number fb-numbers"></span>
                     <span class="points-label">{tr('PTS')}</span>
+                    <span class="base-points completely-hidden">{tr('Capture')}</span>
+                  </div>
+                  <div class="bonus-display completely-hidden">
+                    <span class="bonus-number fb-numbers"></span>
+                    <span class="bonus-label">{tr('PTS')}</span>
+                    <span class="base-bonus">{tr('Hold')}</span>
                   </div>
                   <div class="country-stats">
                     <dl>
@@ -241,6 +247,12 @@ class CountryModalController extends ModalController {
                   <div class="points-display">
                     <span class="points-number fb-numbers"></span>
                     <span class="points-label">{tr('PTS')}</span>
+                    <span class="base-points completely-hidden">{tr('Capture')}</span>
+                  </div>
+                  <div class="bonus-display completely-hidden">
+                    <span class="bonus-number fb-numbers"></span>
+                    <span class="bonus-label">{tr('PTS')}</span>
+                    <span class="base-bonus">{tr('Hold')}</span>
                   </div>
                   <div class="country-stats">
                     <dl>

--- a/src/inc/gameboard/modules/activity.php
+++ b/src/inc/gameboard/modules/activity.php
@@ -13,7 +13,7 @@ class ActivityModuleController extends ModuleController {
     $activity_ul = <ul class="activity-stream"></ul>;
 
     list($all_activity, $config) = await \HH\Asio\va(
-      ActivityLog::genAllActivity(),
+      ActivityLog::genAllActivity(array('held')),
       Configuration::gen('language'),
     );
     $language = $config->getValue();

--- a/src/language/lang_en.php
+++ b/src/language/lang_en.php
@@ -516,6 +516,8 @@ $translations = array(
   //Translations for inc/* and inc/gameboard/*
   'captured' =>
     'captured',
+  'held' =>
+    'held',
   'Status' =>
     'Status',
   'Completed' =>

--- a/src/language/lang_en.php
+++ b/src/language/lang_en.php
@@ -602,6 +602,10 @@ $translations = array(
     'INACTIVE',
   'PTS' =>
     'PTS',
+  'Capture' =>
+    'Capture',
+  'Hold' =>
+    'Hold',
   'category' =>
     'category',
   'capture_' =>

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -148,9 +148,11 @@ class Level extends Model implements Importable, Exportable {
   public static async function importAll(
     array<string, array<string, mixed>> $elements,
   ): Awaitable<bool> {
+    Utils::logMessage('Beginning import of '.count($elements).' levels');
     foreach ($elements as $level) {
       $title = must_have_string($level, 'title');
       $type = must_have_string($level, 'type');
+      Utils::logMessage("> Importing $type level: $title");
       $entity_iso_code = must_have_string($level, 'entity_iso_code');
       $c = must_have_string($level, 'category');
       $exist = await self::genAlreadyExist($type, $title, $entity_iso_code);
@@ -158,11 +160,21 @@ class Level extends Model implements Importable, Exportable {
         Country::genCheckExists($entity_iso_code),
         Category::genCheckExists($c),
       ); // TODO: Combine Awaits
-      if (!$exist && $entity_exist && $category_exist) {
+      if ($exist) {
+        Utils::logMessage('>> Level already exists');
+      } else if (!$entity_exist) {
+        Utils::logMessage(">> Country ($entity_iso_code) does not exist");
+      } else if (!$category_exist) {
+        Utils::logMessage(">> Category ($c) does not exist");
+      } else {
         list($entity, $category) = await \HH\Asio\va(
           Country::genCountry($entity_iso_code),
           Category::genSingleCategoryByName($c),
         ); // TODO: Combine Awaits
+
+        // Handle previous versions
+        $level = self::correctForVersion($level);
+
         $level_id = await self::genCreate(
           $type,
           $title,
@@ -178,6 +190,7 @@ class Level extends Model implements Importable, Exportable {
           must_have_int($level, 'penalty'),
         );
         if (array_key_exists('links', $level)) {
+          Utils::logMessage('>> Importing links');
           $links = must_have_idx($level, 'links');
           invariant(is_array($links), 'links must be of type array');
           foreach ($links as $link) {
@@ -185,6 +198,7 @@ class Level extends Model implements Importable, Exportable {
           }
         }
         if (array_key_exists('attachments', $level)) {
+          Utils::logMessage('>> Importing attachments');
           $attachments = must_have_idx($level, 'attachments');
           invariant(
             is_array($attachments),
@@ -198,9 +212,27 @@ class Level extends Model implements Importable, Exportable {
             ); // TODO: Combine Awaits
           }
         }
+        Utils::logMessage('>> Success');
       }
     }
     return true;
+  }
+
+  private static function correctForVersion(
+    array<string, mixed> $level
+  ): array<string, mixed> {
+    $version = (isset($level['version']) && !is_null($level['version'])) ? $level['version'] : 1;
+    // base versions < 2.0 had bonus & points reversed
+    if ($level['type'] === 'base' && $version < 2) {
+      Utils::logMessage('>> Base version is < 2. Correcting data.');
+      $capture_points = $level['bonus'];
+      $hold_points = $level['points'];
+      $level['points'] = $capture_points;
+      $level['bonus'] = $hold_points;
+      $level['bonus_fix'] = $hold_points;
+    }
+
+    return $level;
   }
 
   // Export levels.
@@ -244,6 +276,7 @@ class Level extends Model implements Importable, Exportable {
         'penalty' => $level->getPenalty(),
         'links' => $link_array,
         'attachments' => $attachment_array,
+        'version' => 2.0
       );
       array_push($all_levels_data, $one_level);
     }
@@ -1140,8 +1173,10 @@ class Level extends Model implements Importable, Exportable {
           $score =
             await ScoreLog::genAllPreviousScore($level_id, $team_id, false);
           if ($score) {
-            $points = $level->getPoints();
+            // If the team has already captured this base, only give the bonus
+            $points = $level->getBonus();
           } else {
+            // Otherwise give capture points
             $points = $level->getPoints() + $level->getBonus();
           }
 

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -1188,7 +1188,7 @@ class Level extends Model implements Importable, Exportable {
           );
 
           // Log the score...
-          await ScoreLog::genLogValidScore(
+          await ScoreLog::genLogBaseScore(
             $level_id,
             $team_id,
             $points,

--- a/src/models/Level.php
+++ b/src/models/Level.php
@@ -1232,7 +1232,8 @@ class Level extends Model implements Importable, Exportable {
   public static async function genBaseIP(int $base_id): Awaitable<string> {
     $links = await Link::genAllLinks($base_id);
     $link = $links[0];
-    $ip = explode(':', $link->getLink())[0];
+    $ip = preg_replace('$[a-zA-Z]+://$', '', $link->getLink());
+    $ip = explode(':', $ip)[0];
 
     return $ip;
   }

--- a/src/static/css/scss/_modals.scss
+++ b/src/static/css/scss/_modals.scss
@@ -165,6 +165,22 @@
 }
 
 /**
+ * --country modal
+ */
+.modal--country-capture {
+  // link display
+  .capture-links {
+    @include flexbox;
+    flex-wrap: wrap;
+
+    & > a,
+    & > input {
+      @include flex(1 0 100%);
+    }
+  }
+}
+
+/**
  * --tutorial
  */
 .fb-tutorial {

--- a/src/static/css/scss/_typography.scss
+++ b/src/static/css/scss/_typography.scss
@@ -382,7 +382,8 @@ table {
 /**
  * --point circles
  */
-.points-display {
+.points-display,
+.bonus-display {
   @include flexbox;
 
   @include align-center;
@@ -397,16 +398,23 @@ table {
   width: 80px;
   height: 80px;
 
-  .points-number {
+  .points-number,
+  .bonus-number {
     font-size: 3em;
     display: block;
     line-height: 1;
   }
 
-  .points-label {
+  .points-label,
+  .bonus-label {
     font-size: .8em;
     text-transform: uppercase;
   }
+}
+
+.bonus-display {
+  margin-left: 10px;
+  margin-right: -10px;
 }
 
 /* --------------------------------------------

--- a/src/static/js/fb-ctf.js
+++ b/src/static/js/fb-ctf.js
@@ -939,7 +939,8 @@ function setupInputListeners() {
             } else {
               var ip = this.split(':')[0];
               var port = this.split(':')[1];
-              link = $('<input/>').attr('type', 'text').attr('disabled', true).attr('value', 'nc ' + ip + ' ' + port);
+              var value = port ? 'nc ' + ip + ' ' + port : ip;
+              link = $('<input/>').attr('type', 'text').attr('readonly', true).attr('value', value);
             }
             $('.capture-links', $container).append(link);
             $('.capture-links', $container).append($('<br/>'));

--- a/src/static/js/fb-ctf.js
+++ b/src/static/js/fb-ctf.js
@@ -909,6 +909,7 @@ function setupInputListeners() {
             hint = data ? data.hint : '',
             hint_cost = data ? data.hint_cost : -1,
             points = data ? data.points : '',
+            bonus = data ? data.bonus : '',
             category = data ? data.category : '',
             type = data ? data.type : '',
             completed = data ? data.completed : '',
@@ -943,11 +944,11 @@ function setupInputListeners() {
               link = $('<input/>').attr('type', 'text').attr('readonly', true).attr('value', value);
             }
             $('.capture-links', $container).append(link);
-            $('.capture-links', $container).append($('<br/>'));
             link_c++;
           });
         }
         $('.points-number', $container).text(points);
+        $('.bonus-number', $container).text(bonus);
         $('.country-type', $container).text(type);
         $('.country-category', $container).text(category);
         $('.country-owner', $container).text(owner);
@@ -959,9 +960,11 @@ function setupInputListeners() {
           });
         }
 
-        // Hide flag submission for bases
+        // Hide flag submission for bases & display base-style points
+        console.log('Country type:', type);
         if (type === 'base') {
-          $('.answer_no_bases').addClass('completely-hidden');
+          $('.answer_no_bases, .points-label, .bonus-label').addClass('completely-hidden');
+          $('.bonus-display, .base-bonus, .base-points').removeClass('completely-hidden');
         }
 
         // Hide flag submission for captured levels
@@ -1106,6 +1109,7 @@ function setupInputListeners() {
             top: mouse_y + 'px'
           }),
               points = data ? data.points : '',
+              bonus = data ? data.bonus : '',
               category = data ? data.category : '',
               title = data ? data.title : '',
               type = data ? data.type : '';
@@ -1113,6 +1117,7 @@ function setupInputListeners() {
           $('.country-name', $container).text(country);
           $('.country-title', $container).text(title);
           $('.points-number', $container).text(points);
+          $('.bonus-number', $container).text(bonus);
           $('.country-type', $container).text(type);
           $('.country-category', $container).text(category);
         });


### PR DESCRIPTION
Improve appearance of bases & links
- Show points for both capturing & holding a base
- Show non-http(s) links as full-width, so they're easier to read
- Show "Capture Points" & "Keep points" when editing bases instead of "Points" & "Bonus"

Mark bases as "held" when the team doesn't change
- Mark as 'held' rather than 'captured' when the controlling team hasn't changed
- Don't spam the gameboard's activity log with messages of a team holding a base
- Show in the activity log when a base is captured by another team

Reverse points/bonus for bases
- More logical to have main points be the capture points, and bonus be the hold points, rather than points = hold, bonus = capture.
- Adding version detection to allow old exports to be imported easily.
- Extra logging to make debugging easier/possible

Functional fixes for bases & links
- Handle http/https/ftp/etc. prefix for base URLs
  - Previously `http://example.com` would lead to the system calling `http:12345`; will now call example.com:12345
- Better display of non-http(s) links
  - If there's a port listed, show the full `nc 1.2.3.4 567`, if not, show just `1.2.3.4` (previously would show `nc 1.2.3.4 undefined)
  - Readonly, rather than disabled, so the text can be scrolled & selected