### PR TITLE
Fix letsencrypt certbot script

### DIFF
--- a/extra/lib.sh
+++ b/extra/lib.sh
@@ -132,14 +132,14 @@ function letsencrypt_cert() {
     cat <<- EOF > /root/tmp/certbot.sh
 		#!/bin/bash
 		if [[ ! ( -d /etc/letsencrypt && "\$(ls -A /etc/letsencrypt)" ) ]]; then
-		    /usr/bin/certbot-auto certonly -n --agree-tos --standalone --standalone-supported-challenges tls-sni-01 -m "$__myemail" -d "$__mydomain"
+		    sudo /usr/bin/certbot-auto certonly -n --agree-tos --standalone --preferred-challenges http -m "$__myemail" -d "$__mydomain"
 		fi
 		sudo ln -sf "/etc/letsencrypt/live/$__mydomain/fullchain.pem" "$1"
 		sudo ln -sf "/etc/letsencrypt/live/$__mydomain/privkey.pem" "$2"
 EOF
     sudo chmod +x /root/tmp/certbot.sh
   else
-    /usr/bin/certbot-auto certonly -n --agree-tos --standalone --standalone-supported-challenges tls-sni-01 -m "$__myemail" -d "$__mydomain"
+    sudo /usr/bin/certbot-auto certonly -n --agree-tos --standalone --preferred-challenges http -m "$__myemail" -d "$__mydomain"
     sudo ln -s "/etc/letsencrypt/live/$__mydomain/fullchain.pem" "$1" || true
     sudo ln -s "/etc/letsencrypt/live/$__mydomain/privkey.pem" "$2" || true
   fi


### PR DESCRIPTION
Previous arguments to cerbot-auto are deprecated and appear to be unsupported.

The setup script `extra/provision.sh` fails and outputs the following messages when it's run with `-c certbot` as an argument:
`Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA.`
`The standalone specific supported challenges flag is deprecated. Please use the --preferred-challenges flag instead.`
There was also a message about rerunning certbot as root which I didn't capture.

Also see:
https://community.letsencrypt.org/t/important-what-you-need-to-know-about-tls-sni-validation-issues/50811
Which states that `tls-sni` is not supported at the moment and
https://letsencrypt.readthedocs.io/en/latest/using.html#standalone
which states that `--standalone-supported-challenges` is deprecated.