### PR TITLE
Certbot on AWS EC2 does not support manual challenge

### DIFF
--- a/extra/lib.sh
+++ b/extra/lib.sh
@@ -139,7 +139,11 @@ function letsencrypt_cert() {
 EOF
     sudo chmod +x /root/tmp/certbot.sh
   else
-    /usr/bin/certbot-auto certonly -n --agree-tos --standalone --standalone-supported-challenges tls-sni-01 -m "$__myemail" -d "$__mydomain"
+    if [ -f /sys/hypervisor/uuid ] && [ `head -c 3 /sys/hypervisor/uuid` == ec2 ]; then
+      /usr/bin/certbot-auto certonly -n --agree-tos --standalone -m "$__myemail" -d "$__mydomain"
+    else
+      /usr/bin/certbot-auto certonly -n --agree-tos --standalone --standalone-supported-challenges tls-sni-01 -m "$__myemail" -d "$__mydomain"
+    fi
     sudo ln -s "/etc/letsencrypt/live/$__mydomain/fullchain.pem" "$1" || true
     sudo ln -s "/etc/letsencrypt/live/$__mydomain/privkey.pem" "$2" || true
   fi


### PR DESCRIPTION
Certbot on AWS EC2 does not support manual challenge tls-sni-01, causes the provision script to break, but can work without it. Removing the standalone challenge.

**Problem:**
The current provision script passed the argument `standalone-supported-challenges` which does not work well with AWS EC2 instance and produces the following error and causes the script to break with the following error:

```
The standalone specific supported challenges flag is deprecated. Please use the --preferred-challenges flag instead.
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator standalone, Installer None
Obtaining a new certificate
Performing the following challenges:
Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA.
Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA.
```

**Solution:**
The fix checks if the instance is an EC2 instance and if yes, it does not supply the manual challenge tls-sni-01 to certbot-auto. This prevents the script from breaking and proceeds perfectly.