### PR TITLE
Fix typo in spanish translation

### DIFF
--- a/src/language/lang_es.php
+++ b/src/language/lang_es.php
@@ -350,7 +350,7 @@ $translations = array(
   'Description' =>
     'Descripción',
   'Level description' =>
-    'Descripción del divel',
+    'Descripción del nivel',
   'Category' =>
     'Categoría',
   'Flag' =>


### PR DESCRIPTION
"Level Description" key has a typo in the translation, it says divel instead of nivel